### PR TITLE
security(deps): bump urllib3 + oauthlib, drop unused espn-api

### DIFF
--- a/pickem/pickem_api/cron_update_games_v2.py
+++ b/pickem/pickem_api/cron_update_games_v2.py
@@ -5,9 +5,6 @@ import json
 from datetime import date
 import argparse
 import os
-import requests
-from datetime import date
-from espn_api.football import League
 
 
 parser = argparse.ArgumentParser(description='Populate/Update NFL Games.')

--- a/pickem/requirements.txt
+++ b/pickem/requirements.txt
@@ -24,10 +24,9 @@ django-ratelimit==4.1.0
 django-storages==1.13.1
 django-tables2==2.4.1
 djangorestframework==3.15.2
-espn-api==0.45.1
 idna==3.15
 jmespath==1.0.1
-oauthlib==3.2.0
+oauthlib==3.2.2
 Pillow==12.2.0
 psycopg2-binary==2.9.3
 pycodestyle==2.11.0
@@ -46,4 +45,4 @@ sqlparse==0.5.4
 tomli==2.0.1
 tzdata==2022.2
 tzlocal==4.2
-urllib3==2.2.3
+urllib3==2.7.0


### PR DESCRIPTION
## What
Clears the remaining Dependabot security alerts not covered by the Django (#36) and soupsieve (#40) Dependabot PRs:
- **urllib3** `2.2.3 → 2.7.0` (several CVEs)
- **oauthlib** `3.2.0 → 3.2.2`

## Why the espn-api removal
`espn-api` hard-pins `urllib3<=2.2.3` (even the latest 0.46.0), which made `pip install -r requirements.txt` unresolvable against `urllib3==2.7.0` — it would break the Docker build. The only use of `espn-api` was a **dead import** (`from espn_api.football import League`) in `cron_update_games_v2.py`; that script actually pulls NFL data straight from the ESPN scoreboard REST API via `requests` and never references `League`. Removing the dead import lets us drop `espn-api`, which unblocks the urllib3 bump.

## Validation
- `pip check` clean after removing espn-api.
- Full test suite: **262 passing**.
- `pip install --dry-run -r requirements.txt` resolves with no conflicts.

## Result
Combined with the two merged Dependabot PRs, this closes all 22 open Dependabot alerts (Django ≥4.2.30, soupsieve 2.8.4, urllib3 2.7.0, oauthlib 3.2.2). Fixes land in prod at the next release (deps are baked into the Docker image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)