### PR TITLE
fix: separate chart releases from app releases

### DIFF
--- a/.github/chart-releaser.yaml
+++ b/.github/chart-releaser.yaml
@@ -1,0 +1,3 @@
+release-name-template: "{{ .Version }}"
+skip-existing: true
+make-release-latest: false

--- a/.github/workflows/publish-artifacts-latest.yaml
+++ b/.github/workflows/publish-artifacts-latest.yaml
@@ -97,5 +97,7 @@ jobs:
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0
+        with:
+          config: .github/chart-releaser.yaml
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/publish-artifacts.yaml
+++ b/.github/workflows/publish-artifacts.yaml
@@ -97,6 +97,8 @@ jobs:
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0
+        with:
+          config: .github/chart-releaser.yaml
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 


### PR DESCRIPTION
## Summary
- configure chart-releaser to publish chart assets to version-only GitHub releases instead of colliding with app deployment releases
- keep chart release reruns idempotent with skip-existing in chart-releaser config
- stop chart-only releases from becoming the repo's GitHub "Latest" release

## Testing
- python YAML parse for chart-releaser config and both workflow files
- git diff --check
