### PR TITLE
fix(board): harden message-board write endpoints from review findings

### DIFF
--- a/pickem/pickem_homepage/tests.py
+++ b/pickem/pickem_homepage/tests.py
@@ -3005,6 +3005,25 @@ class TenantProfilesPlayersMessageBoardIsolationTests(TestCase):
         self.assertEqual(smith_post.content, "Updated content")
         self.assertEqual(smith_post.title, "Updated title")
 
+    def test_tenant_edit_post_rejects_overlong_title_and_content(self):
+        # The form inputs carry maxlength client-side, but a crafted request
+        # bypasses them; the server must reject rather than 500 on DB overflow.
+        smith_post, _smith_comment, _jones_post, _jones_comment = self._seed_message_board_data()
+        self.client.force_login(self.smith_player)
+
+        for payload in (
+            {"title": "x" * 201, "content": "fine"},
+            {"title": "fine", "content": "x" * 2001},
+        ):
+            with self.subTest(payload_keys={k: len(v) for k, v in payload.items()}):
+                response = self._json_post(
+                    self._tenant_url("family_pool_edit_post", post_id=smith_post.id),
+                    payload,
+                )
+                self.assertEqual(response.status_code, 400)
+                smith_post.refresh_from_db()
+                self.assertEqual(smith_post.content, "Smith family only")
+
     def test_tenant_delete_post_allows_author_or_moderator_denies_others(self):
         smith_post, _smith_comment, _jones_post, _jones_comment = self._seed_message_board_data()
         moderator = User.objects.create_user(
@@ -3711,9 +3730,14 @@ class FamilyAdminExperienceTests(TestCase):
         self.family.save(update_fields=["logo_url"])
         self.client.force_login(self.admin_user)
 
-        # "//host/..." is protocol-relative (an arbitrary external host), so it
-        # must not slip through the site-relative-path fast path.
-        for bad_value in ("not a url", "//evil.example/logo.png"):
+        # "//host/..." is protocol-relative (an arbitrary external host) and
+        # browsers normalize "\" to "/", so "/\host/..." resolves the same way
+        # — neither may slip through the site-relative-path fast path.
+        for bad_value in (
+            "not a url",
+            "//evil.example/logo.png",
+            "/\\evil.example/logo.png",
+        ):
             with self.subTest(logo_url=bad_value):
                 response = self.client.post(
                     self._settings_url(),

--- a/pickem/pickem_homepage/tests.py
+++ b/pickem/pickem_homepage/tests.py
@@ -3023,6 +3023,21 @@ class TenantProfilesPlayersMessageBoardIsolationTests(TestCase):
                 self.assertEqual(response.status_code, 400)
                 smith_post.refresh_from_db()
                 self.assertEqual(smith_post.content, "Smith family only")
+                self.assertEqual(smith_post.title, "Smith thread")
+
+    def test_tenant_create_post_rejects_overlong_title(self):
+        self.client.force_login(self.smith_member)
+
+        response = self.client.post(
+            self._tenant_url("family_pool_create_post"),
+            {"title": "x" * 201, "content": "fine"},
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(
+            MessageBoardPost.objects.filter(family=self.smith_family, content="fine").exists()
+        )
 
     def test_tenant_delete_post_allows_author_or_moderator_denies_others(self):
         smith_post, _smith_comment, _jones_post, _jones_comment = self._seed_message_board_data()

--- a/pickem/pickem_homepage/views.py
+++ b/pickem/pickem_homepage/views.py
@@ -3747,6 +3747,14 @@ def create_post_for_family(request, family):
             'errors': {'content': ['Message too long. Please keep it under 2000 characters.']}
         }, status=400)
 
+    # The form input has maxlength=200, but a crafted request bypasses it and
+    # would overflow the CharField into a raw DB error.
+    if len(title) > 200:
+        return JsonResponse({
+            'success': False,
+            'errors': {'title': ['Title too long. Please keep it under 200 characters.']}
+        }, status=400)
+
     try:
         post = MessageBoardPost.objects.create(
             family=family,
@@ -4092,6 +4100,7 @@ def is_board_moderator(request):
 
 
 @login_required
+# @ratelimit(key='user', rate='10/m', method='POST', block=True)  # Disabled for now
 @require_http_methods(["POST"])
 def edit_post(request, post_id):
     return message_board_not_found()
@@ -4133,6 +4142,14 @@ def edit_post_for_family(request, family, post_id):
                 'error': 'Message too long. Please keep it under 2000 characters.'
             }, status=400)
 
+        # The form input has maxlength=200, but a crafted request bypasses it
+        # and would overflow the CharField into a raw DB error.
+        if len(title) > 200:
+            return JsonResponse({
+                'success': False,
+                'error': 'Title too long. Please keep it under 200 characters.'
+            }, status=400)
+
         if not title:
             title = content[:50] + ('...' if len(content) > 50 else '')
 
@@ -4156,14 +4173,15 @@ def edit_post_for_family(request, family, post_id):
             'success': False,
             'error': 'Invalid JSON data'
         }, status=400)
-    except Exception as e:
+    except Exception:
         return JsonResponse({
             'success': False,
-            'error': str(e)
+            'error': 'Something went wrong. Please try again.'
         }, status=500)
 
 
 @login_required
+# @ratelimit(key='user', rate='10/m', method='POST', block=True)  # Disabled for now
 @require_http_methods(["POST"])
 def delete_post(request, post_id):
     return message_board_not_found()
@@ -4196,14 +4214,15 @@ def delete_post_for_family(request, family, post_id):
 
     except Http404:
         return message_board_not_found()
-    except Exception as e:
+    except Exception:
         return JsonResponse({
             'success': False,
-            'error': str(e)
+            'error': 'Something went wrong. Please try again.'
         }, status=500)
 
 
 @login_required
+# @ratelimit(key='user', rate='15/m', method='POST', block=True)  # Disabled for now
 @require_http_methods(["POST"])
 def edit_comment(request, comment_id):
     return message_board_not_found()
@@ -4256,14 +4275,15 @@ def edit_comment_for_family(request, family, comment_id):
             'success': False,
             'error': 'Invalid JSON data'
         }, status=400)
-    except Exception as e:
+    except Exception:
         return JsonResponse({
             'success': False,
-            'error': str(e)
+            'error': 'Something went wrong. Please try again.'
         }, status=500)
 
 
 @login_required
+# @ratelimit(key='user', rate='15/m', method='POST', block=True)  # Disabled for now
 @require_http_methods(["POST"])
 def delete_comment(request, comment_id):
     return message_board_not_found()
@@ -4311,10 +4331,10 @@ def delete_comment_for_family(request, family, comment_id):
 
     except Http404:
         return message_board_not_found()
-    except Exception as e:
+    except Exception:
         return JsonResponse({
             'success': False,
-            'error': str(e)
+            'error': 'Something went wrong. Please try again.'
         }, status=500)
 
 

--- a/pickem/pickem_homepage/views.py
+++ b/pickem/pickem_homepage/views.py
@@ -3768,10 +3768,10 @@ def create_post_for_family(request, family):
             'post_id': post.id,
             'message': 'Message sent successfully!'
         })
-    except Exception as e:
+    except Exception:
         return JsonResponse({
             'success': False,
-            'errors': {'general': [str(e)]}
+            'errors': {'general': ['Something went wrong. Please try again.']}
         }, status=500)
 
 


### PR DESCRIPTION
## Summary

Follow-up hardening from two multi-angle code-review passes over #49 (the review ran after part of that work had already merged):

- **Server-side title length validation** on post create/edit (400 instead of a raw DB `DataError` surfacing through the JSON 500 body — the form's `maxlength=200` is client-side only).
- **Generic 500 messages** in the new edit/delete endpoints' catch-all handlers instead of echoing `str(e)` (leaked internal schema/driver detail to end users).
- **Backslash bypass closed** in `clean_logo_url`: browsers normalize `\` to `/`, so `/\evil.example/x.png` previously slipped the site-relative fast path and resolved protocol-relative to an external host.
- **Conventional disabled `@ratelimit` markers** added to the new edit/delete stubs so a future rate-limit re-enable doesn't silently skip them.

## Tests

- New: `test_tenant_edit_post_rejects_overlong_title_and_content`
- Extended: logo-URL rejection test now covers the backslash variant
- Full suite: 281 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added validation to prevent overly long post titles and content from being submitted or saved.
  - Improved tenant isolation when editing message-board posts.
  - Strengthened validation for invalid family logo URLs.
  - Standardized error messages for post and comment editing or deletion failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->