### PR TITLE
Seed Rams and Jets logo contrast presets in migration

### DIFF
--- a/pickem/pickem_api/migrations/0081_teams_logo_contrast_preset.py
+++ b/pickem/pickem_api/migrations/0081_teams_logo_contrast_preset.py
@@ -1,6 +1,23 @@
 from django.db import migrations, models
 
 
+def seed_logo_contrast_presets(apps, schema_editor):
+    Teams = apps.get_model('pickem_api', 'Teams')
+    Teams.objects.filter(teamNameSlug='rams').update(
+        logo_contrast_preset='reverse-gradient',
+    )
+    Teams.objects.filter(teamNameSlug='jets').update(
+        logo_contrast_preset='white-burst',
+    )
+
+
+def unseed_logo_contrast_presets(apps, schema_editor):
+    Teams = apps.get_model('pickem_api', 'Teams')
+    Teams.objects.filter(teamNameSlug__in=['rams', 'jets']).update(
+        logo_contrast_preset='default',
+    )
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -21,5 +38,9 @@ class Migration(migrations.Migration):
                 help_text='Controls the admin-selected logo contrast treatment for scorecards and other branded surfaces.',
                 max_length=32,
             ),
+        ),
+        migrations.RunPython(
+            seed_logo_contrast_presets,
+            unseed_logo_contrast_presets,
         ),
     ]


### PR DESCRIPTION
## Summary
- seed  to  in the logo contrast preset migration
- seed  to  in the same migration
- keep all other teams on the  preset until explicitly changed in admin

## Verification
- migration diff reviewed for reversible data seeding
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved team logo presentation with tailored contrast presets for select teams, making logos more visible across different backgrounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->