### PR TITLE
Fix unstyled superadmin console in prod (S3 signed-URL cache-buster)

### DIFF
--- a/pickem/pickem_superadmin/templatetags/sa_extras.py
+++ b/pickem/pickem_superadmin/templatetags/sa_extras.py
@@ -9,14 +9,22 @@ register = template.Library()
 
 @register.simple_tag
 def sa_static_v(path):
-    """Static URL with a cache-busting `?v=<mtime>` suffix.
+    """Static URL with a cache-busting `?v=<mtime>` suffix, for LOCAL dev only.
 
     The console's CSS changes often during development and is served with only a
     Last-Modified header, so browsers can hold a stale copy and render the page
-    unstyled. Keying the URL to the file's mtime forces a fresh fetch whenever
-    the file actually changes, and stays stable otherwise.
+    unstyled. Keying the URL to the file's mtime forces a fresh fetch.
+
+    CRITICAL: in production this app serves static files via S3 querystring-
+    signed URLs (`.../tailwind.css?X-Amz-Signature=...`). Appending `?v=` to one
+    of those corrupts the signature and the browser blocks the stylesheet,
+    rendering the whole console unstyled. So we only append the version when the
+    generated URL has NO existing query string — i.e. the plain local-dev case.
+    S3 (and any storage that hashes/signs its URLs) is returned untouched.
     """
     url = static(path)
+    if '?' in url:
+        return url
     absolute = finders.find(path)
     if absolute and os.path.exists(absolute):
         return f'{url}?v={int(os.path.getmtime(absolute))}'

--- a/pickem/pickem_superadmin/tests/test_templatetags.py
+++ b/pickem/pickem_superadmin/tests/test_templatetags.py
@@ -1,0 +1,26 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from pickem_superadmin.templatetags.sa_extras import sa_static_v
+
+
+class SaStaticVTests(TestCase):
+    def test_leaves_signed_s3_urls_untouched(self):
+        """Production serves static via S3 querystring-signed URLs. Appending
+        ?v= would corrupt the signature and the browser would block the CSS, so
+        a URL that already has a query string must be returned unchanged."""
+        signed = 'https://bucket.s3.amazonaws.com/static/css/tailwind.css?X-Amz-Signature=abc123'
+        with patch('pickem_superadmin.templatetags.sa_extras.static', return_value=signed):
+            self.assertEqual(sa_static_v('css/tailwind.css'), signed)
+
+    def test_appends_version_to_plain_local_urls(self):
+        with patch('pickem_superadmin.templatetags.sa_extras.static', return_value='/static/css/tailwind.css'):
+            result = sa_static_v('css/tailwind.css')
+        # Either a ?v= cache-buster (file found on disk) or the plain URL (not
+        # found) — but never a corrupted double query string.
+        self.assertTrue(
+            result == '/static/css/tailwind.css' or result.startswith('/static/css/tailwind.css?v='),
+            result,
+        )
+        self.assertEqual(result.count('?'), 0 if '?' not in result else 1)


### PR DESCRIPTION
The superadmin console renders unstyled in production.

**Cause:** `sa_static_v` (added in the console PR) appends `?v=<mtime>` to the stylesheet URL. Production serves static via **S3 querystring-signed URLs** (`.../tailwind.css?X-Amz-Signature=...`), so the appended `?v=` corrupts the signature → the browser blocks the CSS → unstyled page. This is the same `?v=` footgun this app hit once before. **DEBUG is unrelated** (S3 storage is gated on `AWS_STORAGE_BUCKET_NAME`, not DEBUG).

**Fix:** `sa_static_v` only appends the cache-buster when the URL has no existing query string (plain local-dev). Signed/hashed storage URLs pass through untouched. Regression test added. 454 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved signed static asset URLs that already contain query parameters.
  * Prevented malformed or duplicated query strings in static asset links.
  * Continued supporting cache-busting version parameters for local static assets.

* **Tests**
  * Added coverage for signed external asset URLs and local cache-busted URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->