### PR TITLE
fix: polish auth, family selection, and admin flows

### DIFF
--- a/pickem/pickem/context_processors.py
+++ b/pickem/pickem/context_processors.py
@@ -14,6 +14,7 @@ from pickem_api.authz import (
     AuthenticationRequired,
     PermissionDeniedForTenant,
     TenantNotFound,
+    get_real_user_family_memberships,
     get_user_family_memberships,
     require_tenant_context,
 )
@@ -51,18 +52,12 @@ def theme_context(request):
             context['user_dark_mode'] = user_profile.dark_mode
             context['user_theme_preference'] = 'dark' if user_profile.dark_mode else 'light'
             context['user_is_commissioner'] = user_profile.is_commissioner or request.user.is_superuser
-            # Family commissioners: the owner role in the family model
-            # (rebranded to "Commissioner"), or the legacy profile flag.
-            from pickem_api.models import FamilyMembership
-            context['user_is_commissioner_flag'] = (
-                user_profile.is_commissioner
-                # Superusers act as commissioner in every family (see authz).
-                or request.user.is_superuser
-                or FamilyMembership.objects.filter(
-                    user=request.user,
-                    role=FamilyMembership.Role.OWNER,
-                    status=FamilyMembership.Status.ACTIVE,
-                ).exists()
+            tenant_context = _tenant_context_from_request(request)
+            membership = getattr(tenant_context, 'membership', None)
+            context['user_is_commissioner_flag'] = bool(
+                membership
+                and getattr(membership, 'pk', None)
+                and membership.role == 'owner'
             )
         except Exception as e:
             # Fallback to default values if there's any issue
@@ -156,6 +151,7 @@ def family_switcher_context(request):
         'current_membership': None,
         'family_switcher_choices': [],
         'has_family_memberships': False,
+        'current_user_can_submit_picks': False,
     }
 
     if not getattr(request, 'user', None) or not request.user.is_authenticated:
@@ -164,7 +160,7 @@ def family_switcher_context(request):
     try:
         choices = [
             _switcher_choice_for_membership(membership)
-            for membership in get_user_family_memberships(request.user)
+            for membership in get_real_user_family_memberships(request.user)
         ]
         context['family_switcher_choices'] = choices
         context['has_family_memberships'] = bool(choices)
@@ -175,6 +171,9 @@ def family_switcher_context(request):
             context['current_family'] = tenant_context.family
             context['current_pool'] = tenant_context.pool
             context['current_membership'] = tenant_context.membership
+            context['current_user_can_submit_picks'] = bool(
+                getattr(tenant_context.membership, 'pk', None)
+            )
     except (AuthenticationRequired, TenantNotFound, PermissionDeniedForTenant):
         pass
     except Exception:

--- a/pickem/pickem_api/authz.py
+++ b/pickem/pickem_api/authz.py
@@ -251,3 +251,18 @@ def get_user_family_memberships(user):
     combined = real + extras
     combined.sort(key=lambda m: (m.family.name, m.family.slug))
     return combined
+
+
+def get_real_user_family_memberships(user):
+    """Return only the user's persisted active family memberships.
+
+    Unlike `get_user_family_memberships`, this never expands superusers into
+    synthetic cross-family access. Use it for participant-only features such as
+    picks, family switchers, and "your families" listings.
+    """
+    _require_authenticated(user)
+    return FamilyMembership.objects.filter(
+        user=user,
+        status=FamilyMembership.Status.ACTIVE,
+        family__status=Family.Status.ACTIVE,
+    ).select_related('family').order_by('family__name', 'family__slug')

--- a/pickem/pickem_homepage/templates/account/account_inactive.html
+++ b/pickem/pickem_homepage/templates/account/account_inactive.html
@@ -1,0 +1,27 @@
+{% extends 'pickem/base.html' %}
+{% load static %}
+
+{% block content %}
+<div class="min-h-[calc(100vh-4rem)] flex items-center justify-center px-4 py-12">
+    <div class="w-full max-w-md">
+        <div class="text-center mb-8">
+            <img src="{% static 'images/logo.png' %}" alt="Family Pick'em logo" class="w-16 h-16 mx-auto mb-3">
+            <h1 class="text-2xl font-black text-text-dark dark:text-white">Account unavailable</h1>
+            <p class="text-sm text-text-secondary-light dark:text-text-secondary mt-1">Your sign-in has been disabled.</p>
+        </div>
+
+        <div class="section-container text-center">
+            <div class="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-amber-500/10 text-amber-500">
+                <i class="fas fa-user-lock text-2xl"></i>
+            </div>
+            <p class="text-sm leading-6 text-text-secondary-light dark:text-text-secondary">
+                This account is currently inactive. If you think this is a mistake, contact a Family Pick'em administrator for help.
+            </p>
+            <a href="{% url 'public_home' %}" class="mt-6 inline-flex items-center justify-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-white hover:bg-primary/90 transition-colors">
+                <i class="fas fa-arrow-left"></i>
+                Return to public home
+            </a>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/pickem/pickem_homepage/templates/account/signup.html
+++ b/pickem/pickem_homepage/templates/account/signup.html
@@ -1,0 +1,46 @@
+{% extends 'pickem/base.html' %}
+{% load socialaccount %}
+{% load static %}
+
+{% block content %}
+<div class="min-h-[calc(100vh-4rem)] flex items-center justify-center px-4 py-12">
+    <div class="w-full max-w-md">
+        <div class="text-center mb-8">
+            <img src="{% static 'images/logo.png' %}" alt="Family Pick'em logo" class="w-16 h-16 mx-auto mb-3">
+            <h1 class="text-2xl font-black text-text-dark dark:text-white">Family Pick'em</h1>
+            <p class="text-sm text-text-secondary-light dark:text-text-secondary mt-1">NFL Pick'em League</p>
+        </div>
+
+        <div class="section-container">
+            <h2 class="text-lg font-bold text-text-dark dark:text-white mb-2 text-center">Sign in to create your account</h2>
+            <p class="mb-6 text-center text-sm text-text-secondary-light dark:text-text-secondary">
+                New accounts are created through Google sign-in only.
+            </p>
+
+            {% get_providers as socialaccount_providers %}
+            {% if socialaccount_providers %}
+            <a href="{% provider_login_url 'google' %}"
+               class="w-full flex items-center justify-center gap-3 px-4 py-3 bg-white dark:bg-slate-700 text-gray-700 dark:text-white border border-gray-300 dark:border-slate-600 rounded-xl hover:bg-gray-50 dark:hover:bg-slate-600 transition-all font-semibold shadow-sm">
+                <svg class="w-5 h-5 flex-shrink-0" viewBox="0 0 24 24">
+                    <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
+                    <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+                    <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
+                    <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+                </svg>
+                Continue with Google
+            </a>
+            {% else %}
+            <div class="px-4 py-3 rounded-lg bg-amber-500/10 border border-amber-500/30 text-sm text-amber-500 text-center">
+                Sign-in is temporarily unavailable. Please try again later.
+            </div>
+            {% endif %}
+
+            <div class="mt-5 text-center text-sm">
+                <a href="{% url 'account_login' %}" class="text-text-secondary-light dark:text-text-secondary hover:text-text-dark dark:hover:text-white transition-colors">
+                    Already have an account? Sign in
+                </a>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/pickem/pickem_homepage/templates/pickem/base.html
+++ b/pickem/pickem_homepage/templates/pickem/base.html
@@ -53,7 +53,7 @@
                         Superuser
                     </span>
                     {% endif %}
-                    {% if user_is_commissioner_flag %}
+                    {% if current_family and current_pool and user_is_commissioner_flag %}
                     <!-- Commissioner indicator: single-family governance role -->
                     <span data-testid="commissioner-badge" class="inline-flex items-center gap-1.5 rounded-full border border-sky-400/60 bg-sky-400/15 px-3 py-1 text-xs font-black uppercase tracking-wide text-sky-300" title="You are a commissioner of your family's pool.">
                         <i class="fas fa-gavel" aria-hidden="true"></i>
@@ -80,6 +80,7 @@
                 <!-- Desktop Navigation -->
                 {% if user.is_authenticated %}
                 <div data-testid="app-primary-nav" class="hidden lg:flex items-center space-x-1 absolute left-1/2 transform -translate-x-1/2">
+                    {% if current_family and current_pool %}
                     <a class="nav-link-base" href="{% if current_family and current_pool %}{% url 'family_pool_home' current_family.slug current_pool.slug %}{% else %}{% url 'index' %}{% endif %}" aria-label="Lobby">
                         <i class="fas fa-layer-group"></i>
                     </a>
@@ -116,6 +117,7 @@
                     <a data-testid="tenant-admin-nav" class="nav-link-base" href="{% url 'family_pool_admin' current_family.slug current_pool.slug %}" aria-label="Family Admin">
                         <i class="fas fa-crown"></i>
                     </a>
+                    {% endif %}
                     {% endif %}
                 </div>
                 {% endif %}
@@ -156,7 +158,7 @@
                                 </a>
                             </div>
                         </div>
-                        {% elif family_switcher_choices %}
+                        {% elif family_switcher_choices and request.resolver_match.url_name != 'family_picker' %}
                         <a data-testid="family-context-switcher" class="inline-flex items-center gap-2 px-3 py-2 rounded-xl border border-slate-600 text-white hover:bg-slate-700 transition-colors" href="{% url 'family_picker' %}">
                             <i class="fas fa-users text-primary"></i>
                             <span class="text-sm font-semibold">Switch family</span>
@@ -237,6 +239,7 @@
             <div id="mobile-menu" class="hidden lg:hidden absolute top-16 left-0 right-0 bg-slate-800 border-b border-slate-700 shadow-lg">
                 <div class="px-4 py-4 space-y-2">
                     <!-- Mobile Navigation Links -->
+                    {% if current_family and current_pool %}
                     <a class="block px-4 py-3 text-white hover:bg-slate-700 rounded-lg transition-colors" href="{% if current_family and current_pool %}{% url 'family_pool_home' current_family.slug current_pool.slug %}{% else %}{% url 'index' %}{% endif %}">
                         <i class="fas fa-layer-group mr-3"></i>Lobby
                     </a>
@@ -273,6 +276,7 @@
                         <i class="fas fa-crown mr-3"></i>Family Admin
                     </a>
                     {% endif %}
+                    {% endif %}
 
                     {% if user.is_authenticated %}
                     <div class="border-t border-slate-700 my-2"></div>
@@ -299,7 +303,7 @@
                             <a class="block px-4 py-2 text-sm text-white hover:bg-slate-700 rounded transition-colors" href="{% url 'family_picker' %}">All families</a>
                         </div>
                     </div>
-                    {% elif family_switcher_choices %}
+                    {% elif family_switcher_choices and request.resolver_match.url_name != 'family_picker' %}
                     <a data-testid="family-context-switcher" class="block px-4 py-3 text-white hover:bg-slate-700 rounded-lg transition-colors" href="{% url 'family_picker' %}">
                         <i class="fas fa-users mr-3"></i>Switch family
                     </a>
@@ -313,9 +317,11 @@
                         </a>
                     </div>
                     {% endif %}
+                    {% if current_family and current_pool and current_user_can_submit_picks %}
                     <a class="block px-4 py-3 bg-primary text-white rounded-lg font-semibold text-center" href="{% if current_family and current_pool %}{% url 'family_pool_game_picks' current_family.slug current_pool.slug %}{% else %}{% url 'game_picks' %}{% endif %}">
                         <i class="fas fa-edit mr-2"></i>Submit Weekly Picks
                     </a>
+                    {% endif %}
                     <a class="block px-4 py-3 text-white hover:bg-slate-700 rounded-lg transition-colors" href="{% if current_family and current_pool %}{% url 'family_pool_user_profile' current_family.slug current_pool.slug user.id %}{% else %}{% url 'user_profile' user.id %}{% endif %}">
                         <i class="fas fa-user-circle mr-3"></i>My Profile
                     </a>

--- a/pickem/pickem_homepage/templates/pickem/family_admin_winners.html
+++ b/pickem/pickem_homepage/templates/pickem/family_admin_winners.html
@@ -1,6 +1,6 @@
 {% extends "pickem/base.html" %}
 
-{% block title %}Week Winners - {{ family.name }}{% endblock %}
+{% block title %}Edit Winners - {{ family.name }}{% endblock %}
 
 {% block content %}
 <main class="min-h-screen bg-gray-50 dark:bg-bg-dark">
@@ -8,7 +8,7 @@
         <header class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
             <div>
                 <div class="text-sm font-semibold uppercase tracking-wide text-primary">Family Admin</div>
-                <h1 class="mt-2 text-3xl font-bold text-text-dark dark:text-white">Week Winners</h1>
+                <h1 class="mt-2 text-3xl font-bold text-text-dark dark:text-white">Edit Winners</h1>
                 <p class="mt-2 text-text-secondary-light dark:text-text-secondary">
                     {{ family.name }} - {{ pool.name }} - {{ gameseason }} {{ pool.competition|upper }}
                 </p>
@@ -29,7 +29,7 @@
             <div class="border-b border-border-light dark:border-border-subtle px-5 py-4">
                 <h2 class="text-xl font-bold text-text-dark dark:text-white">Winner Controls</h2>
                 <p class="mt-1 text-sm text-text-secondary-light dark:text-text-secondary">
-                    Current-family candidates with current-pool standings only.
+                    Weekly winners are usually assigned by background jobs. Use this page to review or correct them.
                 </p>
             </div>
 
@@ -56,7 +56,7 @@
                     <label for="winner-uid" class="block text-sm font-semibold text-text-dark dark:text-white">Winner</label>
                     <select id="winner-uid" name="winner_uid" class="mt-2 w-full rounded-lg border border-border-light dark:border-border-subtle bg-white dark:bg-bg-dark px-3 py-3 text-sm text-text-dark dark:text-white" required>
                         {% for candidate in candidates %}
-                        <option value="{{ candidate.uid }}">
+                        <option value="{{ candidate.uid }}" {% if current_winner and current_winner.userID == candidate.uid|stringformat:"s" %}selected{% endif %}>
                             {{ candidate.user.username }} - {{ candidate.wins }} correct pick{{ candidate.wins|pluralize }} - uid {{ candidate.uid }}
                         </option>
                         {% endfor %}
@@ -72,17 +72,40 @@
                 <div class="flex items-end">
                     <button type="submit" class="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-primary px-4 py-3 text-sm font-semibold text-white hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60" {% if not candidates %}disabled{% endif %}>
                         <i class="fas fa-trophy"></i>
-                        Save Winner
+                        Save Changes
                     </button>
                 </div>
             </form>
         </section>
 
+        <section class="grid gap-4 lg:grid-cols-3">
+            <div class="rounded-lg border border-border-light dark:border-border-subtle bg-white dark:bg-surface p-5 shadow-sm">
+                <div class="text-xs font-black uppercase tracking-wide text-text-secondary-light dark:text-text-secondary">Current winner</div>
+                {% if current_winner %}
+                <div class="mt-3 text-xl font-bold text-text-dark dark:text-white">{{ current_winner.userID }}</div>
+                <p class="mt-1 text-sm text-text-secondary-light dark:text-text-secondary">Week {{ selected_week }} currently has a saved winner.</p>
+                {% else %}
+                <div class="mt-3 text-xl font-bold text-text-dark dark:text-white">Not set</div>
+                <p class="mt-1 text-sm text-text-secondary-light dark:text-text-secondary">No winner is saved for this week yet.</p>
+                {% endif %}
+            </div>
+            <div class="rounded-lg border border-border-light dark:border-border-subtle bg-white dark:bg-surface p-5 shadow-sm">
+                <div class="text-xs font-black uppercase tracking-wide text-text-secondary-light dark:text-text-secondary">Eligible players</div>
+                <div class="mt-3 text-3xl font-black text-text-dark dark:text-white">{{ candidates|length }}</div>
+                <p class="mt-1 text-sm text-text-secondary-light dark:text-text-secondary">Only current-family, current-pool candidates are shown here.</p>
+            </div>
+            <div class="rounded-lg border border-border-light dark:border-border-subtle bg-white dark:bg-surface p-5 shadow-sm">
+                <div class="text-xs font-black uppercase tracking-wide text-text-secondary-light dark:text-text-secondary">Weekly winner bonus</div>
+                <div class="mt-3 text-3xl font-black text-text-dark dark:text-white">+{{ pool_settings.weekly_winner_points }}</div>
+                <p class="mt-1 text-sm text-text-secondary-light dark:text-text-secondary">Bonus points awarded when this winner is saved.</p>
+            </div>
+        </section>
+
         <section class="rounded-lg border border-border-light dark:border-border-subtle bg-white dark:bg-surface shadow-sm overflow-hidden">
             <div class="border-b border-border-light dark:border-border-subtle px-5 py-4">
-                <h2 class="text-xl font-bold text-text-dark dark:text-white">Week {{ selected_week }} Candidates</h2>
+                <h2 class="text-xl font-bold text-text-dark dark:text-white">Week {{ selected_week }} Snapshot</h2>
                 <p class="mt-1 text-sm text-text-secondary-light dark:text-text-secondary">
-                    {% if current_winner %}Current winner row #{{ current_winner.id }}{% else %}No winner selected yet{% endif %}
+                    Review the candidates before making edits.
                 </p>
             </div>
             {% if candidates %}
@@ -111,7 +134,7 @@
                 <div class="mx-auto inline-flex h-12 w-12 items-center justify-center rounded-lg bg-gray-100 text-text-secondary-light dark:bg-slate-800 dark:text-text-secondary">
                     <i class="fas fa-trophy"></i>
                 </div>
-                <p class="mt-4 font-semibold text-text-dark dark:text-white">No candidates for this week</p>
+                <p class="mt-4 font-semibold text-text-dark dark:text-white">No eligible players for this week</p>
                 <p class="mt-1 text-sm text-text-secondary-light dark:text-text-secondary">Candidates appear after current-pool picks are scored.</p>
             </div>
             {% endif %}

--- a/pickem/pickem_homepage/templates/pickem/family_messages.html
+++ b/pickem/pickem_homepage/templates/pickem/family_messages.html
@@ -22,8 +22,10 @@
      data-delete-comment-url-template="{% url 'family_pool_delete_comment' family.slug pool.slug 0 %}"
      data-viewer-id="{{ request.user.id }}"
      data-is-moderator="{{ is_moderator|yesno:'1,0' }}"
-     class="max-w-3xl mx-auto px-3 sm:px-4 lg:px-6 py-6">
+     class="mx-auto w-full max-w-7xl overflow-x-hidden px-3 sm:px-4 lg:px-6 py-6">
 
+    <div class="grid gap-6 xl:grid-cols-[minmax(0,1fr)_320px] xl:items-start">
+    <div class="min-w-0">
     <!-- Header -->
     <div class="messages-scoreboard-header rounded-2xl border border-border-light/80 dark:border-border-subtle bg-surface-light/80 dark:bg-surface/80 px-4 py-4 shadow-sm backdrop-blur sm:px-5 mb-5">
         <div class="flex items-center justify-between gap-3">
@@ -43,7 +45,7 @@
     </div>
 
     <!-- Composer -->
-    <div class="rounded-xl border border-border-light dark:border-border-subtle bg-surface-light dark:bg-surface shadow-sm mb-5 overflow-hidden">
+    <div class="w-full min-w-0 rounded-xl border border-border-light dark:border-border-subtle bg-surface-light dark:bg-surface shadow-sm mb-5 overflow-hidden">
         <div class="flex items-center gap-3 border-b border-border-light dark:border-border-subtle px-4 py-3">
             {% with av=request.user.socialaccount_set.first %}
             {% if av %}
@@ -74,15 +76,15 @@
     </div>
 
     <!-- Post list -->
-    <div id="post-list" class="space-y-3">
+    <div id="post-list" class="space-y-3 min-w-0">
         {% for post in posts %}
         <article data-post-id="{{ post.id }}"
                  data-post-title="{% if post.title and post.title != post.content %}{{ post.title }}{% endif %}"
                  data-post-body="{{ post.content }}"
                  data-post-author="{{ post.user|display_name }}"
                  data-post-age="{{ post.created_at|timesince }} ago"
-                 class="message-post rounded-xl border border-border-light dark:border-border-subtle bg-surface-light dark:bg-surface shadow-sm overflow-hidden hover:border-primary/40 transition-colors">
-            <div class="flex">
+                 class="message-post w-full min-w-0 rounded-xl border border-border-light dark:border-border-subtle bg-surface-light dark:bg-surface shadow-sm overflow-hidden hover:border-primary/40 transition-colors">
+            <div class="flex min-w-0">
                 <!-- Vote rail -->
                 <div class="flex flex-col items-center gap-0.5 bg-gray-50 dark:bg-bg-dark/40 px-1.5 py-3">
                     <button type="button" class="vote-btn vote-up flex h-7 w-7 items-center justify-center rounded-md hover:bg-primary/10 {% if post.viewer_vote == 1 %}text-primary{% else %}text-text-secondary-light dark:text-text-secondary{% endif %}" data-vote="1" aria-label="Upvote">
@@ -94,7 +96,7 @@
                     </button>
                 </div>
                 <!-- Body -->
-                <div class="flex-1 min-w-0 p-4">
+                <div class="flex-1 min-w-0 overflow-hidden p-4">
                     <div class="flex items-center gap-2 flex-wrap text-xs text-text-secondary-light dark:text-text-secondary mb-1.5">
                         {% with av=post.user.socialaccount_set.first %}
                         {% if av %}
@@ -149,6 +151,40 @@
         </div>
     </div>
     {% endif %}
+    </div>
+
+    <aside class="hidden xl:block xl:sticky xl:top-24 space-y-4">
+        <section class="rounded-2xl border border-border-light/80 dark:border-border-subtle bg-surface-light/80 dark:bg-surface/80 p-5 shadow-sm">
+            <div class="text-xs font-black uppercase tracking-wide text-primary">Board Pulse</div>
+            <div class="mt-3 grid gap-3">
+                <div class="rounded-xl bg-white/70 dark:bg-bg-dark/40 p-3">
+                    <div class="text-xs font-semibold uppercase tracking-wide text-text-secondary-light dark:text-text-secondary">Threads</div>
+                    <div class="mt-1 text-3xl font-black text-text-dark dark:text-white">{{ total_posts }}</div>
+                </div>
+                <div class="rounded-xl bg-white/70 dark:bg-bg-dark/40 p-3">
+                    <div class="text-xs font-semibold uppercase tracking-wide text-text-secondary-light dark:text-text-secondary">Role</div>
+                    <div class="mt-1 text-lg font-bold text-text-dark dark:text-white">{{ membership.get_role_display }}</div>
+                </div>
+                <div class="rounded-xl bg-white/70 dark:bg-bg-dark/40 p-3">
+                    <div class="text-xs font-semibold uppercase tracking-wide text-text-secondary-light dark:text-text-secondary">Pool</div>
+                    <div class="mt-1 text-lg font-bold text-text-dark dark:text-white">{{ pool.name }}</div>
+                    <div class="text-sm text-text-secondary-light dark:text-text-secondary">{{ pool.display_season }}</div>
+                </div>
+            </div>
+        </section>
+
+        <section class="rounded-2xl border border-border-light/80 dark:border-border-subtle bg-surface-light/80 dark:bg-surface/80 p-5 shadow-sm">
+            <div class="text-xs font-black uppercase tracking-wide text-primary">Posting Notes</div>
+            <div class="mt-3 space-y-3 text-sm text-text-secondary-light dark:text-text-secondary">
+                <p>Use the board for pool chatter, schedule questions, and weekly smack talk.</p>
+                <p>Profiles and settings are still global, even when this board is family-scoped.</p>
+                {% if is_moderator %}
+                <p class="font-semibold text-text-dark dark:text-white">You can edit or remove posts here as a moderator.</p>
+                {% endif %}
+            </div>
+        </section>
+    </aside>
+    </div>
 </div>
 
 <!-- Comments modal -->

--- a/pickem/pickem_homepage/templates/pickem/family_picker.html
+++ b/pickem/pickem_homepage/templates/pickem/family_picker.html
@@ -11,7 +11,7 @@
                 Pick where you want to play
             </h1>
             <p class="text-base text-text-secondary-light dark:text-text-secondary max-w-2xl">
-                These are the active families linked to your account.
+                Use this page to choose a family pool, manage your global profile, or jump into families you oversee as a superuser.
             </p>
         </div>
         <a href="{% url 'create_family' %}" class="inline-flex items-center justify-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-white hover:bg-primary/90 transition-colors">
@@ -20,12 +20,24 @@
         </a>
     </section>
 
-    {% if family_choices %}
+    {% if member_family_choices %}
     <section class="space-y-4">
-        {% for choice in family_choices %}
+        <div>
+            <h2 class="text-sm font-black uppercase tracking-wide text-text-secondary-light dark:text-text-secondary">Families you're part of</h2>
+            <p class="mt-1 text-sm text-text-secondary-light dark:text-text-secondary">Real memberships where you can make picks and play.</p>
+        </div>
+        {% for choice in member_family_choices %}
         <div class="bg-surface-light dark:bg-surface border border-border-light dark:border-border-subtle rounded-lg p-5 flex flex-col md:flex-row md:items-center md:justify-between gap-4">
-            <div>
-                <h2 class="text-xl font-bold text-text-dark dark:text-white">{{ choice.family.name }}</h2>
+            <div class="min-w-0 flex-1">
+                <div class="flex flex-wrap items-center gap-2">
+                    <h2 class="text-xl font-bold text-text-dark dark:text-white">{{ choice.family.name }}</h2>
+                    {% if choice.membership.role == "owner" %}
+                    <span class="inline-flex items-center gap-1 rounded-full border border-sky-400/40 bg-sky-400/10 px-2.5 py-1 text-xs font-bold uppercase tracking-wide text-sky-600 dark:text-sky-300">
+                        <i class="fas fa-gavel text-[10px]"></i>
+                        Family Commissioner
+                    </span>
+                    {% endif %}
+                </div>
                 {% if choice.pool %}
                 <p class="text-sm text-text-secondary-light dark:text-text-secondary">
                     {{ choice.pool.name }} - {{ choice.pool.display_season }}
@@ -37,7 +49,10 @@
                 {% endif %}
             </div>
             {% if choice.url %}
-            <a href="{{ choice.url }}" class="inline-flex items-center justify-center gap-2 px-4 py-2 rounded-lg bg-primary text-white font-semibold hover:bg-primary/90 transition-colors">
+            <a href="{{ choice.url }}" class="inline-flex items-center justify-center gap-3 px-4 py-2 rounded-lg bg-primary text-white font-semibold hover:bg-primary/90 transition-colors">
+                {% if choice.family.logo_url %}
+                <img src="{{ choice.family.logo_url }}" alt="{{ choice.family.name }} logo" class="h-7 w-7 rounded-full object-cover bg-white/20" onerror="this.remove()">
+                {% endif %}
                 <span>Enter pool</span>
                 <i class="fas fa-arrow-right"></i>
             </a>
@@ -49,7 +64,53 @@
         </div>
         {% endfor %}
     </section>
-    {% else %}
+    {% endif %}
+
+    {% if superadmin_family_choices %}
+    <section class="mt-8 space-y-4">
+        <div>
+            <h2 class="text-sm font-black uppercase tracking-wide text-yellow-600 dark:text-yellow-300">Families you can oversee as Superuser</h2>
+            <p class="mt-1 text-sm text-text-secondary-light dark:text-text-secondary">You can administer these families, but you are not a playing member unless you join them directly.</p>
+        </div>
+        {% for choice in superadmin_family_choices %}
+        <div class="bg-surface-light dark:bg-surface border border-border-light dark:border-border-subtle rounded-lg p-5 flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+            <div class="min-w-0 flex-1">
+                <div class="flex flex-wrap items-center gap-2">
+                    <h2 class="text-xl font-bold text-text-dark dark:text-white">{{ choice.family.name }}</h2>
+                    <span class="inline-flex items-center gap-1 rounded-full border border-yellow-400/40 bg-yellow-400/10 px-2.5 py-1 text-xs font-bold uppercase tracking-wide text-yellow-700 dark:text-yellow-300">
+                        <i class="fas fa-bolt text-[10px]"></i>
+                        Superuser
+                    </span>
+                </div>
+                {% if choice.pool %}
+                <p class="text-sm text-text-secondary-light dark:text-text-secondary">
+                    {{ choice.pool.name }} - {{ choice.pool.display_season }}
+                </p>
+                {% else %}
+                <p class="text-sm text-text-secondary-light dark:text-text-secondary">
+                    This family needs an active pool before play can begin.
+                </p>
+                {% endif %}
+            </div>
+            {% if choice.url %}
+            <a href="{{ choice.url }}" class="inline-flex items-center justify-center gap-3 px-4 py-2 rounded-lg border border-yellow-400/40 bg-yellow-400/10 text-yellow-700 dark:text-yellow-200 font-semibold hover:bg-yellow-400/15 transition-colors">
+                {% if choice.family.logo_url %}
+                <img src="{{ choice.family.logo_url }}" alt="{{ choice.family.name }} logo" class="h-7 w-7 rounded-full object-cover bg-white/20" onerror="this.remove()">
+                {% endif %}
+                <span>Open family</span>
+                <i class="fas fa-arrow-right"></i>
+            </a>
+            {% else %}
+            <span class="inline-flex items-center justify-center px-4 py-2 rounded-lg bg-border-light dark:bg-surface-hover text-text-secondary-light dark:text-text-secondary font-semibold">
+                Pool setup needed
+            </span>
+            {% endif %}
+        </div>
+        {% endfor %}
+    </section>
+    {% endif %}
+
+    {% if not member_family_choices and not superadmin_family_choices %}
     <section class="bg-surface-light dark:bg-surface border border-border-light dark:border-border-subtle rounded-lg p-6">
         <h2 class="text-xl font-bold text-text-dark dark:text-white mb-2">No active families</h2>
         <p class="text-sm text-text-secondary-light dark:text-text-secondary mb-4">

--- a/pickem/pickem_homepage/templates/pickem/home.html
+++ b/pickem/pickem_homepage/templates/pickem/home.html
@@ -216,6 +216,21 @@
             {% endif %}
         </div>
     </section>
+
+    <footer class="landing-section relative z-10 border-t border-white/10 bg-slate-950 px-5 py-10 sm:px-8 lg:px-10">
+        <div class="mx-auto flex max-w-7xl flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+                <div class="text-sm font-black uppercase tracking-[0.24em] text-slate-400">Family Pick'em</div>
+                <p class="mt-2 max-w-xl text-sm leading-6 text-slate-400">Public site footer for future company and policy pages.</p>
+            </div>
+            <div class="flex flex-wrap gap-3 text-sm font-bold text-slate-300">
+                <span class="rounded-full border border-white/10 px-4 py-2">About Us</span>
+                <span class="rounded-full border border-white/10 px-4 py-2">Terms of Use</span>
+                <span class="rounded-full border border-white/10 px-4 py-2">Privacy Policy</span>
+                <span class="rounded-full border border-white/10 px-4 py-2">Contact Us</span>
+            </div>
+        </div>
+    </footer>
 </div>
 
 <script src="https://cdn.jsdelivr.net/npm/gsap@3.13.0/dist/gsap.min.js" integrity="sha384-HOvlOYPIs/zjoIkWUGXkVmXsjr8GuZLV+Q+rcPwmJOVZVpvTSXQChiN4t9Euv9Vc" crossorigin="anonymous"></script>

--- a/pickem/pickem_homepage/templates/pickem/rules.html
+++ b/pickem/pickem_homepage/templates/pickem/rules.html
@@ -243,7 +243,7 @@
                 <div class="rules-compact-card rounded-lg border border-border-light dark:border-border-subtle bg-white/80 dark:bg-surface/80 p-4 shadow-sm">
                     <div class="flex items-center justify-between mb-3">
                         <span class="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
-                            <i class="fas fa-sack-dollar"></i>
+                            <i class="fas fa-coins"></i>
                         </span>
                     </div>
                     <div class="font-bold text-text-dark dark:text-white">Payout Structure</div>

--- a/pickem/pickem_homepage/tests.py
+++ b/pickem/pickem_homepage/tests.py
@@ -1545,6 +1545,25 @@ class TenantPickFlowIsolationTests(TestCase):
         self.assertEqual(response.json()["saved_pool_ids"], [self.smith_pool.id])
         self.assertFalse(GamePicks.objects.filter(pool=outsider_pool, userID=str(self.member.id)).exists())
 
+    def test_superuser_without_real_membership_cannot_open_or_submit_picks(self):
+        site_admin = User.objects.create_user(
+            "site-admin-picks",
+            email="site-admin-picks@example.com",
+            password="pass",
+            is_superuser=True,
+        )
+        self.client.force_login(site_admin)
+
+        page_response = self.client.get(self._tenant_picks_url())
+        post_response = self.client.post(
+            self._tenant_picks_url(),
+            self._pick_payload(),
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+
+        self.assertEqual(page_response.status_code, 404)
+        self.assertEqual(post_response.status_code, 404)
+
     def test_tenant_post_rejects_game_outside_current_week_context(self):
         self.client.force_login(self.member)
 
@@ -2947,16 +2966,13 @@ class TenantProfilesPlayersMessageBoardIsolationTests(TestCase):
         self.assertTemplateUsed(response, "pickem/user_profile_private.html")
         self.assertContains(response, "This Profile is Private")
 
-    def test_legacy_signed_in_profile_redirects_to_default_tenant_profile(self):
+    def test_legacy_signed_in_profile_renders_global_profile_without_tenant_redirect(self):
         self.client.force_login(self.smith_member)
 
         response = self.client.get(reverse("user_profile", kwargs={"user_id": self.smith_player.id}))
 
-        self.assertRedirects(
-            response,
-            self._tenant_url("family_pool_user_profile", user_id=self.smith_player.id),
-            fetch_redirect_response=False,
-        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "pickem/user_profile.html")
 
     def test_legacy_anonymous_profile_detail_is_not_available(self):
         response = self.client.get(reverse("user_profile", kwargs={"user_id": self.smith_player.id}))
@@ -3782,11 +3798,8 @@ class FamilyAdminExperienceTests(TestCase):
             admin_page = self.client.get(self._admin_url(family=family, pool=pool))
             self.assertEqual(admin_page.status_code, 200)
 
-        # The switcher lists every active family (incl. any legacy family)...
-        self.assertLessEqual(
-            {self.family.slug, self.other_family.slug},
-            {c["family"].slug for c in lobby.context["family_switcher_choices"]},
-        )
+        # The switcher is reserved for real memberships only.
+        self.assertEqual(lobby.context["family_switcher_choices"], [])
         # ...without creating any membership rows (no roster contamination).
         self.assertFalse(FamilyMembership.objects.filter(user=sre).exists())
 
@@ -3804,7 +3817,7 @@ class FamilyAdminExperienceTests(TestCase):
         )
         self.assertNotContains(own_lobby, 'data-testid="superuser-badge"')
 
-    def test_commissioner_badge_shows_for_flag_and_stacks_with_superuser(self):
+    def test_commissioner_badge_is_scoped_to_the_current_family_owner_membership(self):
         lobby_url = reverse(
             "family_pool_home",
             kwargs={"family_slug": self.family.slug, "pool_slug": self.pool.slug},
@@ -3824,20 +3837,20 @@ class FamilyAdminExperienceTests(TestCase):
         self.assertNotContains(page, 'data-testid="superuser-badge"')
         self.client.force_login(self.member)
 
-        # Commissioner flag -> commissioner badge only. (The first page view
-        # auto-creates the profile, so update rather than create.)
+        # A legacy profile flag alone no longer grants the family-scoped badge.
         UserProfile.objects.update_or_create(
             user=self.member, defaults={"is_commissioner": True}
         )
         page = self.client.get(lobby_url)
-        self.assertContains(page, 'data-testid="commissioner-badge"')
+        self.assertNotContains(page, 'data-testid="commissioner-badge"')
         self.assertNotContains(page, 'data-testid="superuser-badge"')
 
-        # Commissioner + superuser -> both badges.
+        # Superuser without the owner membership still only shows the global
+        # superuser badge.
         self.member.is_superuser = True
         self.member.save(update_fields=["is_superuser"])
         page = self.client.get(lobby_url)
-        self.assertContains(page, 'data-testid="commissioner-badge"')
+        self.assertNotContains(page, 'data-testid="commissioner-badge"')
         self.assertContains(page, 'data-testid="superuser-badge"')
 
     def _settings_url(self, *, family=None, pool=None):
@@ -5339,7 +5352,7 @@ class FamilyAdminExperienceTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "pickem/family_admin_winners.html")
-        self.assertContains(response, "Week Winners")
+        self.assertContains(response, "Edit Winners")
         self.assertContains(response, "Smith Family")
         self.assertContains(response, self.member.username)
         self.assertContains(response, str(current_pick.uid))
@@ -5603,7 +5616,7 @@ class CreateFamilyFlowTests(TestCase):
         )
         self.assertEqual(family.slug, "smith-family")
         self.assertEqual(family.status, Family.Status.ACTIVE)
-        self.assertEqual(pool.name, "Pickem Pool")
+        self.assertEqual(pool.name, "NFL Pick'em - 2025 - 2026")
         self.assertEqual(pool.slug, "pickem-pool")
         self.assertEqual(pool.season, get_season())
         self.assertEqual(pool.competition, "nfl")
@@ -6787,6 +6800,24 @@ class GlobalLeaderboardTests(TestCase):
         self.admin = User.objects.create_user(
             "admin-gl", email="admin-gl@example.com", password="x", is_superuser=True
         )
+        FamilyMembership.objects.create(
+            family=self.smith_family,
+            user=self.alice,
+            role=FamilyMembership.Role.MEMBER,
+            status=FamilyMembership.Status.ACTIVE,
+        )
+        FamilyMembership.objects.create(
+            family=self.smith_family,
+            user=self.bob,
+            role=FamilyMembership.Role.MEMBER,
+            status=FamilyMembership.Status.ACTIVE,
+        )
+        FamilyMembership.objects.create(
+            family=self.smith_family,
+            user=self.admin,
+            role=FamilyMembership.Role.MEMBER,
+            status=FamilyMembership.Status.ACTIVE,
+        )
 
     def _points(self, pool, user, total):
         return userSeasonPoints.objects.create(
@@ -6839,6 +6870,21 @@ class GlobalLeaderboardTests(TestCase):
         alice = next(e for e in response.context["entries"] if e["userID"] == str(self.alice.id))
         self.assertEqual(alice["accuracy"], 80)  # 8/10 from the global row, not 9/20
 
+    def test_leaderboard_includes_active_member_with_no_points_row(self):
+        FamilyMembership.objects.create(
+            family=self.jones_family,
+            user=self.bob,
+            role=FamilyMembership.Role.MEMBER,
+            status=FamilyMembership.Status.ACTIVE,
+        )
+
+        response = self.client.get(reverse("global_leaderboard"))
+
+        entries = {e["userID"]: e for e in response.context["entries"]}
+        self.assertIn(str(self.bob.id), entries)
+        self.assertEqual(entries[str(self.bob.id)]["points"], 0)
+        self.assertEqual(entries[str(self.bob.id)]["leagues"], 0)
+
     def test_players_tied_at_zero_share_rank_one_and_podium_is_hidden(self):
         # Season just started: everyone has a standings row but no points, so
         # all players must be tied at rank 1 (not 1,2,3) and the podium hidden.
@@ -6858,6 +6904,12 @@ class GlobalLeaderboardTests(TestCase):
         self._points(self.smith_pool, self.alice, 10)
         self._points(self.smith_pool, self.bob, 10)
         carol = User.objects.create_user("carol-gl", email="carol-gl@example.com", password="x")
+        FamilyMembership.objects.create(
+            family=self.smith_family,
+            user=carol,
+            role=FamilyMembership.Role.MEMBER,
+            status=FamilyMembership.Status.ACTIVE,
+        )
         self._points(self.smith_pool, carol, 5)
 
         response = self.client.get(reverse("global_leaderboard"))

--- a/pickem/pickem_homepage/urls.py
+++ b/pickem/pickem_homepage/urls.py
@@ -172,6 +172,8 @@ urlpatterns = [
     path('scores/', views.scores, name='scores'),
     path('standings/', views.standings, name='standings'),
     path('rules/', views.rules, name='rules'),
+    path('accounts/signup/', views.account_signup_google_only, name='account_signup'),
+    path('accounts/inactive/', views.account_inactive, name='account_inactive'),
     path('accounts/', include('allauth.urls')),
     # POST-only: logout via GET is deprecated (removed in Django 5) and would
     # let third-party pages log users out (CSRF).

--- a/pickem/pickem_homepage/views.py
+++ b/pickem/pickem_homepage/views.py
@@ -50,6 +50,7 @@ from pickem_api.authz import (
     AuthenticationRequired,
     PermissionDeniedForTenant,
     TenantNotFound,
+    get_real_user_family_memberships,
     get_user_family_memberships,
     require_tenant_context,
 )
@@ -57,6 +58,15 @@ from pickem_api.models import Family, FamilyAuditLog, FamilyInvitation, FamilyMe
 from pickem_homepage.authz import family_member_required
 
 ESPN_NEWS_URL = 'https://site.api.espn.com/apis/site/v2/sports/football/nfl/news'
+
+
+@require_http_methods(["GET", "POST"])
+def account_signup_google_only(request):
+    return render(request, 'account/signup.html', {'gameseason': get_season()})
+
+
+def account_inactive(request):
+    return render(request, 'account/account_inactive.html', {'gameseason': get_season()})
 
 
 def get_espn_nfl_news(limit=6):
@@ -286,6 +296,28 @@ def get_default_active_pool_for_family(family):
     )
 
 
+def format_display_season_range(season):
+    season_str = str(season or "").zfill(4)
+    if len(season_str) == 4 and season_str.isdigit():
+        return f"20{season_str[:2]} - 20{season_str[2:]}"
+    return str(season or "")
+
+
+def default_pool_name(*, season, competition='nfl'):
+    competition_labels = {
+        'nfl': "NFL Pick'em",
+    }
+    competition_label = competition_labels.get(
+        (competition or '').lower(),
+        (competition or 'Pool').upper(),
+    )
+    return f"{competition_label} - {format_display_season_range(season)}"
+
+
+def has_real_family_membership(membership):
+    return bool(getattr(membership, 'pk', None))
+
+
 def generate_unique_slug(model, value, *, scoped_filters=None, max_length=80):
     base_slug = slugify(value)[:max_length].strip('-') or 'family'
     scoped_filters = scoped_filters or {}
@@ -320,7 +352,7 @@ def generate_invite_code():
 
 def get_family_pool_choices(user):
     choices = []
-    for membership in get_user_family_memberships(user):
+    for membership in get_real_user_family_memberships(user):
         family = membership.family
         pool = get_default_active_pool_for_family(family)
         choices.append({
@@ -386,9 +418,9 @@ def build_family_admin_sections(family, pool, user=None):
     # single entry point, and only to superadmins.
     if user is not None and getattr(user, 'is_superuser', False):
         sections.append({
-            'label': 'Superadmin',
+            'label': 'Super Admin',
             'description': 'Cross-family operator console — health, settings, users, jobs, and repair tools.',
-            'icon': 'fas fa-shield-halved',
+            'icon': 'fas fa-user-shield',
             'url': '/superadmin/',
             'status': 'Open console',
         })
@@ -407,6 +439,8 @@ def get_current_week_context(gameseason):
 def redirect_to_default_pool_route(request, route_name, **route_kwargs):
     family_choices = get_family_pool_choices(request.user)
     if not family_choices:
+        if getattr(request.user, 'is_superuser', False) and get_user_family_memberships(request.user):
+            return redirect('family_picker')
         return redirect('onboarding')
     if len(family_choices) > 1:
         return redirect('family_picker')
@@ -677,10 +711,10 @@ def create_family(request):
             )
             pool = Pool.objects.create(
                 family=family,
-                name='Pickem Pool',
+                name=default_pool_name(season=get_season(), competition='nfl'),
                 slug=generate_unique_slug(
                     Pool,
-                    'Pickem Pool',
+                    'pickem-pool',
                     scoped_filters={'family': family},
                 ),
                 season=get_season(),
@@ -848,12 +882,33 @@ def create_family_invite(request, family_slug, pool_slug):
 
 @login_required
 def family_picker(request):
-    choices = get_family_pool_choices(request.user)
-    if not choices:
+    member_choices = get_family_pool_choices(request.user)
+    visible_family_ids = {choice['family'].id for choice in member_choices}
+    superadmin_choices = []
+    if request.user.is_superuser:
+        for membership in get_user_family_memberships(request.user):
+            if membership.family_id in visible_family_ids:
+                continue
+            family = membership.family
+            pool = get_default_active_pool_for_family(family)
+            superadmin_choices.append({
+                'membership': membership,
+                'family': family,
+                'pool': pool,
+                'url': reverse(
+                    'family_pool_home',
+                    kwargs={'family_slug': family.slug, 'pool_slug': pool.slug},
+                ) if pool else None,
+                'is_superadmin_access': True,
+            })
+
+    if not member_choices and not superadmin_choices:
         return redirect('onboarding')
 
     context = {
-        'family_choices': choices,
+        'family_choices': member_choices,
+        'member_family_choices': member_choices,
+        'superadmin_family_choices': superadmin_choices,
         'gameseason': get_season(),
     }
     return render(request, 'pickem/family_picker.html', context)
@@ -1650,7 +1705,7 @@ def render_family_admin_winners(request, tenant_context, form=None, *, status=20
         .order_by('id')
         .first()
     )
-    pool_settings = PoolSettings.objects.filter(pool=pool).first()
+    pool_settings = PoolSettings.objects.filter(pool=pool).first() or PoolSettings()
     context = {
         'family': family,
         'pool': pool,
@@ -2432,23 +2487,30 @@ def global_leaderboard(request):
     )
 
     User = get_user_model()
-    # Only real competitors — no admins, no deactivated accounts.
-    valid_ids = {
+    season_pools = Pool.objects.filter(season=season, status=Pool.Status.ACTIVE)
+    competitor_ids = {
         str(uid)
-        for uid in User.objects.filter(
-            is_active=True, is_superuser=False
-        ).values_list('id', flat=True)
+        for uid in FamilyMembership.objects.filter(
+            family__pools__in=season_pools,
+            status=FamilyMembership.Status.ACTIVE,
+            user__is_active=True,
+            user__is_superuser=False,
+        ).values_list('user_id', flat=True).distinct()
     }
 
     # Blend every pool: total points + number of leagues per player this season.
-    points_rows = (
-        userSeasonPoints.objects.filter(gameseason=season)
-        .values('userID')
-        .annotate(
-            points=Coalesce(Sum('total_points'), 0),
-            leagues=Count('pool', distinct=True),
+    points_rows = {
+        str(row['userID']): row
+        for row in (
+            userSeasonPoints.objects.filter(gameseason=season)
+            .values('userID')
+            .annotate(
+                points=Coalesce(Sum('total_points'), 0),
+                leagues=Count('pool', distinct=True),
+            )
         )
-    )
+        if row['userID']
+    }
 
     # Accuracy + weeks won, blended across the player's pools. The pool-null row
     # already IS that all-pools aggregate; summing per-pool rows in alongside it
@@ -2465,18 +2527,16 @@ def global_leaderboard(request):
             stats_by_user[str(row['userID'])] = row
 
     entries = []
-    for row in points_rows:
-        uid = str(row['userID'] or '')
-        if uid not in valid_ids:
-            continue
+    for uid in sorted(competitor_ids, key=int):
+        row = points_rows.get(uid, {})
         s = stats_by_user.get(uid, {})
         correct = s.get('correct') or 0
         total = s.get('total') or 0
         accuracy = round((correct / total) * 100) if total else None
         entries.append({
             'userID': uid,
-            'points': row['points'] or 0,
-            'leagues': row['leagues'] or 0,
+            'points': row.get('points') or 0,
+            'leagues': row.get('leagues') or 0,
             'weeks_won': s.get('weeks_won') or 0,
             'correct': correct,
             'accuracy': accuracy,
@@ -2515,7 +2575,7 @@ def global_leaderboard(request):
         'avatars': avatars,
         'has_scores': has_scores,
         'total_players': len(entries),
-        'total_leagues': Pool.objects.filter(season=season).count(),
+        'total_leagues': season_pools.count(),
     }
     return render(request, 'pickem/global_leaderboard.html', context)
 
@@ -3025,6 +3085,8 @@ def tenant_submit_game_picks(request, family_slug, pool_slug):
 
 def render_pick_page(request, *, tenant_context=None):
     is_default_week = False
+    if tenant_context and not has_real_family_membership(tenant_context.membership):
+        raise Http404
     gameseason = tenant_context.pool.season if tenant_context else get_season()
     game_week, game_competition = get_current_week_context(gameseason)
     if not GameWeeks.objects.filter(
@@ -3207,6 +3269,10 @@ def tenant_edit_game_pick(request, family_slug, pool_slug):
     if request.method != 'POST':
         return JsonResponse({'error': True, 'message': 'Only POST requests allowed'}, status=405)
     
+    tenant_context = request.tenant_context
+    if not has_real_family_membership(tenant_context.membership):
+        raise Http404
+
     try:
         pick_id = request.POST.get('pick_id')
         new_pick = request.POST.get('pick')
@@ -3216,8 +3282,6 @@ def tenant_edit_game_pick(request, family_slug, pool_slug):
         if not pick_id or not new_pick:
             return JsonResponse({'error': True, 'message': 'Missing required fields'}, status=400)
         
-        tenant_context = request.tenant_context
-
         # Get the existing pick through current pool and user scope before any lock/team checks.
         try:
             existing_pick = GamePicks.objects.get(
@@ -3456,13 +3520,9 @@ def profile(request):
 
 
 def user_profile(request, user_id):
-    """Legacy profile route. Signed-in users are bridged into tenant context."""
+    """Global profile route used when no family/pool tenant is selected."""
     if request.user.is_authenticated:
-        return redirect_to_default_pool_route(
-            request,
-            'family_pool_user_profile',
-            user_id=user_id,
-        )
+        return render_user_profile(request, user_id, tenant_context=None)
     raise Http404
 
 


### PR DESCRIPTION
## Summary

Polishes several auth, onboarding, family-selection, admin, and messaging edge cases across the site.

## Included fixes

- Restyled `/accounts/inactive/` so blocked users land on a proper themed page.
- Replaced local signup with a Google-only signup page that mirrors the login flow.
- Removed tenant nav icons from `/families/` until a family/pool is selected while keeping global profile/settings access.
- Split family picker behavior between real memberships and superuser-only oversight access.
- Allowed global profile/settings access without forcing a tenant redirect.
- Prevented synthetic superuser-only family access from being treated like playable membership for picks and switcher behavior.
- Restricted the nav switcher to real memberships only.
- Changed new default pool naming to `NFL Pick'em - YYYY - YYYY`.
- Renamed the admin tile to `Super Admin` and refreshed the winners page into an edit/correction flow.
- Added the missing payout icon.
- Expanded the desktop messages layout and prevented mobile horizontal scrolling.
- Added family logos next to the family CTA when a custom logo exists.
- Added a footer placeholder section to `/public/`.
- Tightened the public leaderboard so active family members in current-season pools are included even when they do not yet have a standings row.
- Added/updated tests covering the new access rules and leaderboard behavior.

## Verification

- `DJANGO_SETTINGS_MODULE=pickem.test_settings python manage.py test pickem_homepage.tests.GlobalLeaderboardTests pickem_homepage.tests.FamilyAdminExperienceTests pickem_homepage.tests.TenantPickFlowIsolationTests`
- `curl http://localhost:8000/public/`
- `curl http://localhost:8000/accounts/signup/`
- `curl http://localhost:8000/accounts/inactive/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Google-only account signup and an account-unavailable page for disabled accounts.
  * Expanded family selection with membership roles and separate super-admin options.
  * Added footer links to public pages and a sidebar summary to the message board.
  * Improved winner editing with clearer labels, summaries, and eligible-player details.

* **Bug Fixes**
  * Restricted commissioner badges, navigation, and pick submission to valid family memberships.
  * Improved leaderboard eligibility and inclusion of members with zero points.
  * Updated profile behavior when no family or pool is selected.

* **Style**
  * Refined navigation, family cards, message board layout, and rules-page iconography.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->