### PR TITLE
fix: tighten public leaderboard and family picker polish

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -316,3 +316,11 @@ Production deployments use:
 - Environment-based configuration (see `settings.py` for RDS/K8s detection)
 
 GitHub Actions workflows in `.github/workflows/` handle artifact publishing.
+
+### Release Workflow
+
+- Production release publishing is triggered by publishing a GitHub Release, not by pushing a git tag alone.
+- The workflow [`.github/workflows/publish-artifacts.yaml`](.github/workflows/publish-artifacts.yaml) runs on `release: published`.
+- The release tag format is `family-pickem-<version>` (example: `family-pickem-0.0.159`).
+- Pushing the tag without creating the GitHub Release will not run the production release workflow.
+- The workflow [`.github/workflows/publish-artifacts-latest.yaml`](.github/workflows/publish-artifacts-latest.yaml) runs separately on pushes to `main` and handles the `-latest` publish flow.

--- a/pickem/pickem/context_processors.py
+++ b/pickem/pickem/context_processors.py
@@ -38,7 +38,7 @@ def theme_context(request):
         'user_dark_mode': None,
         'user_theme_preference': None,
         'user_is_commissioner': False,
-        # Pure profile flag (no superuser OR) — drives the Commissioner badge.
+        # Tenant-scoped owner flag derived from the current family membership.
         'user_is_commissioner_flag': False,
         # Stable per-deployment cache-buster for static assets (see settings).
         'static_version': settings.STATIC_VERSION,

--- a/pickem/pickem_homepage/templates/pickem/base.html
+++ b/pickem/pickem_homepage/templates/pickem/base.html
@@ -318,7 +318,7 @@
                     </div>
                     {% endif %}
                     {% if current_family and current_pool and current_user_can_submit_picks %}
-                    <a class="block px-4 py-3 bg-primary text-white rounded-lg font-semibold text-center" href="{% if current_family and current_pool %}{% url 'family_pool_game_picks' current_family.slug current_pool.slug %}{% else %}{% url 'game_picks' %}{% endif %}">
+                    <a class="block px-4 py-3 bg-primary text-white rounded-lg font-semibold text-center" href="{% url 'family_pool_game_picks' current_family.slug current_pool.slug %}">
                         <i class="fas fa-edit mr-2"></i>Submit Weekly Picks
                     </a>
                     {% endif %}

--- a/pickem/pickem_homepage/templates/pickem/family_picker.html
+++ b/pickem/pickem_homepage/templates/pickem/family_picker.html
@@ -68,7 +68,7 @@
 
     {% if superadmin_family_choices %}
     <section class="mt-8 space-y-4">
-        <div>
+        <div class="pt-2">
             <h2 class="text-sm font-black uppercase tracking-wide text-yellow-600 dark:text-yellow-300">Families you can oversee as Superuser</h2>
             <p class="mt-1 text-sm text-text-secondary-light dark:text-text-secondary">You can administer these families, but you are not a playing member unless you join them directly.</p>
         </div>
@@ -107,19 +107,6 @@
             {% endif %}
         </div>
         {% endfor %}
-    </section>
-    {% endif %}
-
-    {% if not member_family_choices and not superadmin_family_choices %}
-    <section class="bg-surface-light dark:bg-surface border border-border-light dark:border-border-subtle rounded-lg p-6">
-        <h2 class="text-xl font-bold text-text-dark dark:text-white mb-2">No active families</h2>
-        <p class="text-sm text-text-secondary-light dark:text-text-secondary mb-4">
-            Create a family or join one with an invite code.
-        </p>
-        <a href="{% url 'onboarding' %}" class="inline-flex items-center justify-center gap-2 px-4 py-2 rounded-lg bg-primary text-white font-semibold hover:bg-primary/90 transition-colors">
-            <i class="fas fa-arrow-left"></i>
-            <span>Go to setup</span>
-        </a>
     </section>
     {% endif %}
 </main>

--- a/pickem/pickem_homepage/templates/pickem/home.html
+++ b/pickem/pickem_homepage/templates/pickem/home.html
@@ -217,17 +217,17 @@
         </div>
     </section>
 
-    <footer class="landing-section relative z-10 border-t border-white/10 bg-slate-950 px-5 py-10 sm:px-8 lg:px-10">
+    <footer class="landing-section relative z-10 border-t border-border-light dark:border-border-subtle bg-surface dark:bg-bg-dark px-5 py-10 sm:px-8 lg:px-10">
         <div class="mx-auto flex max-w-7xl flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
             <div>
-                <div class="text-sm font-black uppercase tracking-[0.24em] text-slate-400">Family Pick'em</div>
-                <p class="mt-2 max-w-xl text-sm leading-6 text-slate-400">Public site footer for future company and policy pages.</p>
+                <div class="text-sm font-black uppercase tracking-[0.24em] text-text-secondary-light dark:text-text-secondary">Family Pick'em</div>
+                <p class="mt-2 max-w-xl text-sm leading-6 text-text-secondary-light dark:text-text-secondary">Public site footer for future company and policy pages.</p>
             </div>
-            <div class="flex flex-wrap gap-3 text-sm font-bold text-slate-300">
-                <span class="rounded-full border border-white/10 px-4 py-2">About Us</span>
-                <span class="rounded-full border border-white/10 px-4 py-2">Terms of Use</span>
-                <span class="rounded-full border border-white/10 px-4 py-2">Privacy Policy</span>
-                <span class="rounded-full border border-white/10 px-4 py-2">Contact Us</span>
+            <div class="flex flex-wrap gap-3 text-sm font-bold text-text-dark dark:text-text-primary">
+                <span class="rounded-full border border-border-light dark:border-border-subtle px-4 py-2">About Us</span>
+                <span class="rounded-full border border-border-light dark:border-border-subtle px-4 py-2">Terms of Use</span>
+                <span class="rounded-full border border-border-light dark:border-border-subtle px-4 py-2">Privacy Policy</span>
+                <span class="rounded-full border border-border-light dark:border-border-subtle px-4 py-2">Contact Us</span>
             </div>
         </div>
     </footer>

--- a/pickem/pickem_homepage/tests.py
+++ b/pickem/pickem_homepage/tests.py
@@ -15,6 +15,7 @@ from django.http import Http404, HttpResponse
 from django.test import TestCase, Client, RequestFactory
 from django.urls import reverse
 from django.utils import timezone
+from allauth.socialaccount.models import SocialAccount, SocialApp
 
 from pickem.utils import get_season
 from pickem_api.models import (
@@ -5616,7 +5617,9 @@ class CreateFamilyFlowTests(TestCase):
         )
         self.assertEqual(family.slug, "smith-family")
         self.assertEqual(family.status, Family.Status.ACTIVE)
-        self.assertEqual(pool.name, "NFL Pick'em - 2025 - 2026")
+        season_raw = str(get_season()).zfill(4)
+        expected_pool_name = f"NFL Pick'em - 20{season_raw[:2]} - 20{season_raw[2:]}"
+        self.assertEqual(pool.name, expected_pool_name)
         self.assertEqual(pool.slug, "pickem-pool")
         self.assertEqual(pool.season, get_season())
         self.assertEqual(pool.competition, "nfl")
@@ -6782,6 +6785,18 @@ class GlobalLeaderboardTests(TestCase):
     def setUp(self):
         self.client = Client()
         self.season = 2526
+        site, _ = Site.objects.get_or_create(
+            id=1, defaults={"domain": "testserver", "name": "testserver"}
+        )
+        social_app, _ = SocialApp.objects.get_or_create(
+            provider="google",
+            defaults={
+                "name": "Google",
+                "client_id": "test-client-id",
+                "secret": "test-secret",
+            },
+        )
+        social_app.sites.add(site)
         currentSeason.objects.create(season=self.season, display_name="2025-2026")
         self.smith_family = Family.objects.create(name="Smith", slug="smith-gl")
         self.jones_family = Family.objects.create(name="Jones", slug="jones-gl")
@@ -6800,6 +6815,8 @@ class GlobalLeaderboardTests(TestCase):
         self.admin = User.objects.create_user(
             "admin-gl", email="admin-gl@example.com", password="x", is_superuser=True
         )
+        self._link_google(self.alice, given_name="Alice")
+        self._link_google(self.bob, given_name="Bob")
         FamilyMembership.objects.create(
             family=self.smith_family,
             user=self.alice,
@@ -6817,6 +6834,14 @@ class GlobalLeaderboardTests(TestCase):
             user=self.admin,
             role=FamilyMembership.Role.MEMBER,
             status=FamilyMembership.Status.ACTIVE,
+        )
+
+    def _link_google(self, user, *, given_name=None):
+        return SocialAccount.objects.create(
+            user=user,
+            provider="google",
+            uid=f"google-{user.id}",
+            extra_data={"given_name": given_name or user.username},
         )
 
     def _points(self, pool, user, total):
@@ -6847,6 +6872,16 @@ class GlobalLeaderboardTests(TestCase):
     def test_leaderboard_excludes_superusers_and_blends_accuracy(self):
         self._points(self.smith_pool, self.alice, 10)
         self._points(self.smith_pool, self.admin, 999)  # admin must not appear
+        local_adminjim = User.objects.create_user(
+            "ADMINJIM", email="adminjim@example.com", password="x"
+        )
+        FamilyMembership.objects.create(
+            family=self.smith_family,
+            user=local_adminjim,
+            role=FamilyMembership.Role.MEMBER,
+            status=FamilyMembership.Status.ACTIVE,
+        )
+        self._points(self.smith_pool, local_adminjim, 250)
         # The global leaderboard blends accuracy from the pool-null (global)
         # userStats row — the one update_stats writes per user in its default,
         # season-wide run. A per-pool row (pool=<pool>) is a different record and
@@ -6867,6 +6902,7 @@ class GlobalLeaderboardTests(TestCase):
         ids = [e["userID"] for e in response.context["entries"]]
         self.assertIn(str(self.alice.id), ids)
         self.assertNotIn(str(self.admin.id), ids)
+        self.assertNotIn(str(local_adminjim.id), ids)
         alice = next(e for e in response.context["entries"] if e["userID"] == str(self.alice.id))
         self.assertEqual(alice["accuracy"], 80)  # 8/10 from the global row, not 9/20
 
@@ -6904,6 +6940,7 @@ class GlobalLeaderboardTests(TestCase):
         self._points(self.smith_pool, self.alice, 10)
         self._points(self.smith_pool, self.bob, 10)
         carol = User.objects.create_user("carol-gl", email="carol-gl@example.com", password="x")
+        self._link_google(carol, given_name="Carol")
         FamilyMembership.objects.create(
             family=self.smith_family,
             user=carol,

--- a/pickem/pickem_homepage/views.py
+++ b/pickem/pickem_homepage/views.py
@@ -2495,6 +2495,7 @@ def global_leaderboard(request):
             status=FamilyMembership.Status.ACTIVE,
             user__is_active=True,
             user__is_superuser=False,
+            user__socialaccount__provider='google',
         ).values_list('user_id', flat=True).distinct()
     }
 
@@ -3269,8 +3270,8 @@ def tenant_edit_game_pick(request, family_slug, pool_slug):
     if request.method != 'POST':
         return JsonResponse({'error': True, 'message': 'Only POST requests allowed'}, status=405)
     
-    tenant_context = request.tenant_context
-    if not has_real_family_membership(tenant_context.membership):
+    tenant_context = getattr(request, 'tenant_context', None)
+    if tenant_context is None or not has_real_family_membership(tenant_context.membership):
         raise Http404
 
     try:


### PR DESCRIPTION
## Summary
- exclude local-only accounts from the public leaderboard and keep the new family picker grouped cleanly
- address the still-valid CodeRabbit cleanup comments from #61 and add the release-flow note to AGENTS
- add/update focused tests for Google-only leaderboard visibility and dynamic pool naming

## Testing
- source venv/bin/activate && cd pickem && DJANGO_SETTINGS_MODULE=pickem.test_settings python manage.py test pickem_homepage.tests.CreateFamilyFlowTests pickem_homepage.tests.GlobalLeaderboardTests pickem_homepage.tests.FamilyAdminExperienceTests pickem_homepage.tests.TenantPickFlowIsolationTests

## Notes
- I intentionally kept the family-scoped commissioner badge behavior unchanged because that matches the tenant authorization model already enforced in code and tests.
