### PR TITLE
fix: harden helm release publishing

### DIFF
--- a/.github/chart-releaser.yaml
+++ b/.github/chart-releaser.yaml
@@ -1,3 +1,0 @@
-release-name-template: "{{ .Version }}"
-skip-existing: true
-make-release-latest: false

--- a/.github/workflows/publish-artifacts-latest.yaml
+++ b/.github/workflows/publish-artifacts-latest.yaml
@@ -69,8 +69,8 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     needs: [get_tag, run_tests]
-    # Shared with the release workflow's publish_helm so the two chart-releaser
-    # runs never push to gh-pages at the same time (avoids non-fast-forward).
+    # Shared with the release workflow's publish_helm because both publish
+    # directly to gh-pages.
     concurrency:
       group: helm-chart-release
       cancel-in-progress: false
@@ -92,12 +92,41 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@v3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.5.0
-        with:
-          config: .github/chart-releaser.yaml
-        env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Package chart
+        run: |
+          mkdir -p .chart-packages
+          helm dependency build ./charts/family-pickem
+          helm package ./charts/family-pickem --destination .chart-packages
+          test -f ".chart-packages/family-pickem-${{needs.get_tag.outputs.tag}}.tgz"
+
+      - name: Publish chart to gh-pages
+        run: |
+          git fetch origin gh-pages
+          rm -rf .gh-pages
+          git worktree add .gh-pages origin/gh-pages
+          cp ".chart-packages/family-pickem-${{needs.get_tag.outputs.tag}}.tgz" .gh-pages/
+          (
+            cd .gh-pages
+            helm repo index . \
+              --url https://jimdaga.github.io/family-pickem \
+              --merge index.yaml
+            git config user.name "$GITHUB_ACTOR"
+            git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+            git add "family-pickem-${{needs.get_tag.outputs.tag}}.tgz" index.yaml
+            git diff --cached --quiet && echo "No chart changes to commit" && exit 0
+            git commit -m "chore: publish helm chart ${{needs.get_tag.outputs.tag}}"
+            git push origin HEAD:gh-pages
+          )
+
+      - name: Verify chart version is in published index
+        run: |
+          for attempt in $(seq 1 18); do
+            if curl -fsSL https://jimdaga.github.io/family-pickem/index.yaml | grep -Fq "version: ${{needs.get_tag.outputs.tag}}"; then
+              exit 0
+            fi
+            echo "Waiting for gh-pages to publish chart ${{needs.get_tag.outputs.tag}} (attempt ${attempt}/18)"
+            sleep 10
+          done
+          echo "Chart ${{needs.get_tag.outputs.tag}} was not visible in the published Helm index"
+          exit 1

--- a/.github/workflows/publish-artifacts.yaml
+++ b/.github/workflows/publish-artifacts.yaml
@@ -65,9 +65,8 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
-    # Serialize with the main-branch "-latest" workflow: both run chart-releaser
-    # which pushes index.yaml to gh-pages, and concurrent pushes lose the race
-    # (non-fast-forward). Queue instead of cancel so neither publish is dropped.
+    # Serialize with the main-branch "-latest" workflow because both publish
+    # directly to gh-pages.
     concurrency:
       group: helm-chart-release
       cancel-in-progress: false
@@ -100,15 +99,50 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@v3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.5.0
-        with:
-          config: .github/chart-releaser.yaml
+      - name: Package chart
         env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          HELM_VERSION: ${{ steps.vars.outputs.helm_version }}
+        run: |
+          mkdir -p .chart-packages
+          helm dependency build ./charts/family-pickem
+          helm package ./charts/family-pickem --destination .chart-packages
+          test -f ".chart-packages/family-pickem-${HELM_VERSION}.tgz"
+
+      - name: Publish chart to gh-pages
+        env:
+          HELM_VERSION: ${{ steps.vars.outputs.helm_version }}
+        run: |
+          git fetch origin gh-pages
+          rm -rf .gh-pages
+          git worktree add .gh-pages origin/gh-pages
+          cp ".chart-packages/family-pickem-${HELM_VERSION}.tgz" .gh-pages/
+          (
+            cd .gh-pages
+            helm repo index . \
+              --url https://jimdaga.github.io/family-pickem \
+              --merge index.yaml
+            git config user.name "$GITHUB_ACTOR"
+            git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+            git add "family-pickem-${HELM_VERSION}.tgz" index.yaml
+            git diff --cached --quiet && echo "No chart changes to commit" && exit 0
+            git commit -m "chore: publish helm chart ${HELM_VERSION}"
+            git push origin HEAD:gh-pages
+          )
+
+      - name: Verify chart version is in published index
+        env:
+          HELM_VERSION: ${{ steps.vars.outputs.helm_version }}
+        run: |
+          for attempt in $(seq 1 18); do
+            if curl -fsSL https://jimdaga.github.io/family-pickem/index.yaml | grep -Fq "version: ${HELM_VERSION}"; then
+              exit 0
+            fi
+            echo "Waiting for gh-pages to publish chart ${HELM_VERSION} (attempt ${attempt}/18)"
+            sleep 10
+          done
+          echo "Chart ${HELM_VERSION} was not visible in the published Helm index"
+          exit 1
 
   update_argocd:
     name: Update ArgoCD production app version

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -324,3 +324,5 @@ GitHub Actions workflows in `.github/workflows/` handle artifact publishing.
 - The release tag format is `family-pickem-<version>` (example: `family-pickem-0.0.159`).
 - Pushing the tag without creating the GitHub Release will not run the production release workflow.
 - The workflow [`.github/workflows/publish-artifacts-latest.yaml`](.github/workflows/publish-artifacts-latest.yaml) runs separately on pushes to `main` and handles the `-latest` publish flow.
+- Helm chart publishing is critical to deploys: before advancing ArgoCD, the workflow must publish `family-pickem-<version>.tgz` to `gh-pages` and verify that `https://jimdaga.github.io/family-pickem/index.yaml` contains the target version.
+- If ArgoCD shows `chart "family-pickem" version "<version>" not found`, the release likely updated `pickem-prd.yaml` before the public Helm repo actually served that chart version.


### PR DESCRIPTION
## Summary
- replace chart-releaser-based Helm publishing with direct Helm package + gh-pages publish
- verify the target chart version is visible in the public Helm index before ArgoCD advances production
- document the failure mode in AGENTS.md

## Why
The `family-pickem-0.0.162` production release updated ArgoCD to `0.0.162`, but the public Helm repo never exposed chart version `0.0.162`. ArgoCD then failed with `chart "family-pickem" version "0.0.162" not found` and prod stayed on `0.0.161` until manual recovery.

## Verification
- YAML parse of both workflow files
- manual recovery proved Helm index propagation and ArgoCD reconciliation once `0.0.162` was actually published
- prod now healthy on `familypickem/pickem-django:0.0.162`
