### PR TITLE
feat: simplify invite links

### DIFF
--- a/pickem/pickem_homepage/emailing.py
+++ b/pickem/pickem_homepage/emailing.py
@@ -72,12 +72,10 @@ def send_family_invitation_email(*, invitation, invite_link, invite_code):
             f"<p><a href=\"{invite_link}\">Accept your invite</a></p>"
             f"<p>If the button does not work, use this invite link:</p>"
             f"<p>{invite_link}</p>"
-            f"<p>Fallback invite code: <code>{invite_code}</code></p>"
         ),
         'text': (
             f"You have been invited to join {invitation.family.name} on Family Pick'em.\n\n"
-            f"Accept your invite: {invite_link}\n\n"
-            f"Fallback invite code: {invite_code}"
+            f"Accept your invite: {invite_link}"
         ),
     }
     if config['reply_to']:

--- a/pickem/pickem_homepage/forms.py
+++ b/pickem/pickem_homepage/forms.py
@@ -343,28 +343,19 @@ class FamilyInviteCreateForm(forms.Form):
     role = forms.ChoiceField(required=True)
     recipient_email = forms.EmailField(
         label="Recipient email",
-        required=False,
+        required=True,
         widget=forms.EmailInput(attrs={
             'class': ADMIN_TEXT_INPUT_CLASSES,
             'autocomplete': 'email',
-            'placeholder': 'optional@example.com',
+            'placeholder': 'invitee@example.com',
         }),
-        help_text="Optional. If set, only that email address can redeem the invite.",
+        help_text="The invite link will only work once and only for this email address.",
     )
     expires_in_days = forms.IntegerField(
         label="Expires after",
         min_value=1,
         max_value=365,
         initial=14,
-        widget=forms.NumberInput(attrs={
-            'class': ADMIN_TEXT_INPUT_CLASSES,
-        }),
-    )
-    max_uses = forms.IntegerField(
-        label="Max uses",
-        min_value=1,
-        max_value=1000,
-        initial=20,
         widget=forms.NumberInput(attrs={
             'class': ADMIN_TEXT_INPUT_CLASSES,
         }),

--- a/pickem/pickem_homepage/templates/pickem/family_admin_invites.html
+++ b/pickem/pickem_homepage/templates/pickem/family_admin_invites.html
@@ -36,21 +36,17 @@
         </section>
         {% endif %}
 
-        {% if invite_code %}
+        {% if invite_link %}
         <section class="rounded-lg border border-primary/30 bg-white dark:bg-surface p-5 shadow-sm" data-testid="invite-created-once">
-            <p class="text-xs font-bold uppercase tracking-wider text-primary">Invite created - copy now</p>
-            <h2 class="mt-1 text-lg font-bold text-text-dark dark:text-white">This raw code is only shown once</h2>
+            <p class="text-xs font-bold uppercase tracking-wider text-primary">Invite created</p>
+            <h2 class="mt-1 text-lg font-bold text-text-dark dark:text-white">This invite link is only shown once</h2>
             <p class="mt-2 text-sm text-text-secondary-light dark:text-text-secondary">
-                Share the invite link when possible. The raw code below is fallback-only.
+                Send this one-time link to the invited user if the email was not delivered automatically.
             </p>
             <div class="mt-4 grid gap-3">
                 <div>
                     <p class="mb-2 text-xs font-semibold uppercase tracking-wide text-text-secondary-light dark:text-text-secondary">Invite link</p>
                     <code class="block rounded-lg border border-border-light dark:border-border-subtle bg-gray-50 dark:bg-bg-dark px-4 py-3 text-sm text-text-dark dark:text-white break-all font-mono">{{ invite_link }}</code>
-                </div>
-                <div>
-                    <p class="mb-2 text-xs font-semibold uppercase tracking-wide text-text-secondary-light dark:text-text-secondary">Raw code</p>
-                    <code class="block rounded-lg border border-border-light dark:border-border-subtle bg-gray-50 dark:bg-bg-dark px-4 py-3 text-sm text-text-dark dark:text-white break-all font-mono">{{ invite_code }}</code>
                 </div>
             </div>
         </section>
@@ -63,7 +59,7 @@
                     Admins can create member invites. Owners can also create admin invites.
                 </p>
             </div>
-            <form method="post" action="{% url 'family_pool_admin_invites' family.slug pool.slug %}" class="grid gap-4 p-5 md:grid-cols-5" data-testid="invite-create-form">
+            <form method="post" action="{% url 'family_pool_admin_invites' family.slug pool.slug %}" class="grid gap-4 p-5 md:grid-cols-4" data-testid="invite-create-form">
                 {% csrf_token %}
                 <div>
                     <label for="{{ form.role.id_for_label }}" class="block text-sm font-semibold text-text-dark dark:text-white">Role</label>
@@ -87,17 +83,10 @@
                     <p class="mt-1 text-sm text-red-600 dark:text-red-300">{{ error }}</p>
                     {% endfor %}
                 </div>
-                <div>
-                    <label for="{{ form.max_uses.id_for_label }}" class="block text-sm font-semibold text-text-dark dark:text-white">Max Uses</label>
-                    <div class="mt-2">{{ form.max_uses }}</div>
-                    {% for error in form.max_uses.errors %}
-                    <p class="mt-1 text-sm text-red-600 dark:text-red-300">{{ error }}</p>
-                    {% endfor %}
-                </div>
                 <div class="flex items-end">
                     <button type="submit" class="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-primary px-4 py-3 text-sm font-semibold text-white hover:bg-primary/90">
                         <i class="fas fa-ticket-alt"></i>
-                        Create Invite
+                        Send Invite
                     </button>
                 </div>
             </form>
@@ -107,7 +96,7 @@
             <div class="border-b border-border-light dark:border-border-subtle px-5 py-4">
                 <h2 class="text-xl font-bold text-text-dark dark:text-white">Invite History</h2>
                 <p class="mt-1 text-sm text-text-secondary-light dark:text-text-secondary">
-                    Safe metadata only. Raw invite codes and hashes are never redisplayed here.
+                    One-time invites are locked to a single email address. Invite links are never redisplayed here.
                 </p>
             </div>
 
@@ -120,7 +109,7 @@
                             <th class="px-5 py-3 text-left text-xs font-semibold uppercase text-text-secondary-light dark:text-text-secondary">Role</th>
                             <th class="px-5 py-3 text-left text-xs font-semibold uppercase text-text-secondary-light dark:text-text-secondary">Recipient</th>
                             <th class="px-5 py-3 text-left text-xs font-semibold uppercase text-text-secondary-light dark:text-text-secondary">Status</th>
-                            <th class="px-5 py-3 text-left text-xs font-semibold uppercase text-text-secondary-light dark:text-text-secondary">Uses</th>
+                            <th class="px-5 py-3 text-left text-xs font-semibold uppercase text-text-secondary-light dark:text-text-secondary">Accepted</th>
                             <th class="px-5 py-3 text-left text-xs font-semibold uppercase text-text-secondary-light dark:text-text-secondary">Expires</th>
                             <th class="px-5 py-3 text-left text-xs font-semibold uppercase text-text-secondary-light dark:text-text-secondary">Created</th>
                             <th class="px-5 py-3 text-left text-xs font-semibold uppercase text-text-secondary-light dark:text-text-secondary">Creator</th>
@@ -132,7 +121,7 @@
                         <tr>
                             <td class="px-5 py-4 text-sm font-semibold text-text-dark dark:text-white">#{{ invite.id }}</td>
                             <td class="px-5 py-4 text-sm text-text-secondary-light dark:text-text-secondary">{{ invite.get_role_display }}</td>
-                            <td class="px-5 py-4 text-sm text-text-secondary-light dark:text-text-secondary">{{ invite.recipient_email|default:"Anyone with link" }}</td>
+                            <td class="px-5 py-4 text-sm text-text-secondary-light dark:text-text-secondary">{{ invite.recipient_email|default:"No recipient set" }}</td>
                             <td class="px-5 py-4">
                                 {% if invite.is_revoked %}
                                 <span class="inline-flex rounded-lg bg-gray-100 px-3 py-1 text-sm font-semibold text-gray-700 dark:bg-slate-800 dark:text-text-secondary">Revoked</span>
@@ -140,7 +129,7 @@
                                 <span class="inline-flex rounded-lg bg-green-100 px-3 py-1 text-sm font-semibold text-green-800 dark:bg-green-900/30 dark:text-green-300">Active</span>
                                 {% endif %}
                             </td>
-                            <td class="px-5 py-4 text-sm text-text-secondary-light dark:text-text-secondary">{{ invite.use_count }} / {% if invite.max_uses %}{{ invite.max_uses }}{% else %}Unlimited{% endif %}</td>
+                            <td class="px-5 py-4 text-sm text-text-secondary-light dark:text-text-secondary">{% if invite.use_count %}Yes{% else %}No{% endif %}</td>
                             <td class="px-5 py-4 text-sm text-text-secondary-light dark:text-text-secondary whitespace-nowrap">{% if invite.expires_at %}{{ invite.expires_at|date:"M j, Y" }}{% else %}Never{% endif %}</td>
                             <td class="px-5 py-4 text-sm text-text-secondary-light dark:text-text-secondary whitespace-nowrap">{{ invite.created_at|date:"M j, Y" }}</td>
                             <td class="px-5 py-4 text-sm text-text-secondary-light dark:text-text-secondary">{% if invite.created_by %}{{ invite.created_by.username }}{% else %}System{% endif %}</td>
@@ -171,7 +160,7 @@
                         <div>
                             <h3 class="font-bold text-text-dark dark:text-white">Invite #{{ invite.id }}</h3>
                             <p class="text-sm text-text-secondary-light dark:text-text-secondary">{{ invite.get_role_display }} by {% if invite.created_by %}{{ invite.created_by.username }}{% else %}System{% endif %}</p>
-                            <p class="mt-1 text-sm text-text-secondary-light dark:text-text-secondary">{{ invite.recipient_email|default:"Anyone with link" }}</p>
+                            <p class="mt-1 text-sm text-text-secondary-light dark:text-text-secondary">{{ invite.recipient_email|default:"No recipient set" }}</p>
                         </div>
                         {% if invite.is_revoked %}
                         <span class="rounded-lg bg-gray-100 px-3 py-1 text-sm font-semibold text-gray-700 dark:bg-slate-800 dark:text-text-secondary">Revoked</span>
@@ -181,8 +170,8 @@
                     </div>
                     <dl class="mt-4 grid grid-cols-2 gap-3 text-sm">
                         <div>
-                            <dt class="font-semibold text-text-dark dark:text-white">Uses</dt>
-                            <dd class="text-text-secondary-light dark:text-text-secondary">{{ invite.use_count }} / {% if invite.max_uses %}{{ invite.max_uses }}{% else %}Unlimited{% endif %}</dd>
+                            <dt class="font-semibold text-text-dark dark:text-white">Accepted</dt>
+                            <dd class="text-text-secondary-light dark:text-text-secondary">{% if invite.use_count %}Yes{% else %}No{% endif %}</dd>
                         </div>
                         <div>
                             <dt class="font-semibold text-text-dark dark:text-white">Expires</dt>
@@ -210,7 +199,7 @@
                     <i class="fas fa-ticket-alt"></i>
                 </div>
                 <p class="mt-4 font-semibold text-text-dark dark:text-white">No invites yet</p>
-                <p class="mt-1 text-sm text-text-secondary-light dark:text-text-secondary">Created invites will appear here without raw codes.</p>
+                <p class="mt-1 text-sm text-text-secondary-light dark:text-text-secondary">Created invites will appear here without reusable invite links.</p>
             </div>
             {% endif %}
         </section>

--- a/pickem/pickem_homepage/templates/pickem/family_pool_home.html
+++ b/pickem/pickem_homepage/templates/pickem/family_pool_home.html
@@ -410,12 +410,11 @@
     </div>
 
     <!-- Invite code (shown once after creation) -->
-    {% if invite_code %}
+    {% if invite_link %}
     <div class="lobby-section section-container mb-8 border-primary/30">
         <p class="text-xs font-bold uppercase tracking-wider text-text-secondary-light dark:text-text-secondary mb-1">Invite created — copy now</p>
-        <h2 class="text-lg font-bold text-text-dark dark:text-white mb-3">This code is only shown once</h2>
+        <h2 class="text-lg font-bold text-text-dark dark:text-white mb-3">This invite link is only shown once</h2>
         <div class="space-y-2">
-            <code class="block rounded-xl border border-border-light dark:border-border-subtle bg-white dark:bg-surface-hover px-4 py-3 text-sm text-text-dark dark:text-white break-all font-mono">{{ invite_code }}</code>
             <code class="block rounded-xl border border-border-light dark:border-border-subtle bg-white dark:bg-surface-hover px-4 py-3 text-sm text-text-dark dark:text-white break-all font-mono">{{ invite_link }}</code>
         </div>
     </div>

--- a/pickem/pickem_homepage/templates/pickem/join_family.html
+++ b/pickem/pickem_homepage/templates/pickem/join_family.html
@@ -10,7 +10,7 @@
             Join a family pick'em league
         </h1>
         <p class="text-base text-text-secondary-light dark:text-text-secondary max-w-2xl">
-            Enter the invite code from your family owner.
+            Open the invitation link from your email. If needed, you can paste the invite link here.
         </p>
     </section>
 
@@ -19,7 +19,7 @@
             {% csrf_token %}
             <div>
                 <label for="{{ form.code.id_for_label }}" class="block text-sm font-semibold text-text-dark dark:text-white mb-2">
-                    Invite code
+                    Invitation link
                 </label>
                 {{ form.code }}
                 {% if form.code.errors %}

--- a/pickem/pickem_homepage/templates/pickem/onboarding.html
+++ b/pickem/pickem_homepage/templates/pickem/onboarding.html
@@ -10,7 +10,7 @@
             Start your family pick'em league
         </h1>
         <p class="text-base text-text-secondary-light dark:text-text-secondary max-w-2xl">
-            Create a private family league or join one with an invite code before making picks.
+            Create a private family league or join one from an invitation email before making picks.
         </p>
     </section>
 
@@ -34,23 +34,17 @@
         <div class="bg-surface-light dark:bg-surface border border-border-light dark:border-border-subtle rounded-lg p-6">
             <div class="flex items-center gap-3 mb-4">
                 <span class="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-slate-700 text-white">
-                    <i class="fas fa-ticket"></i>
+                    <i class="fas fa-envelope-open-text"></i>
                 </span>
-                <h2 class="text-xl font-bold text-text-dark dark:text-white">Join with a code</h2>
+                <h2 class="text-xl font-bold text-text-dark dark:text-white">Join from your email</h2>
             </div>
             <p class="text-sm text-text-secondary-light dark:text-text-secondary mb-5">
-                Use an invite from your family owner to enter their pool.
+                Ask your commissioner to send you an invite. The email link will add you to the family.
             </p>
-            <form action="{% url 'join_family' %}" method="get" class="flex flex-col sm:flex-row gap-3">
-                <label class="sr-only" for="invite_code">Invite code</label>
-                <input id="invite_code" name="code" type="text" autocomplete="off"
-                       class="flex-1 rounded-lg border border-border-light dark:border-border-subtle bg-white dark:bg-surface-hover px-3 py-2 text-text-dark dark:text-white"
-                       placeholder="Invite code">
-                <button type="submit" class="inline-flex items-center justify-center gap-2 px-4 py-2 rounded-lg bg-slate-800 text-white font-semibold hover:bg-slate-700 transition-colors">
-                    <i class="fas fa-arrow-right"></i>
-                    <span>Join</span>
-                </button>
-            </form>
+            <a href="{% url 'join_family' %}" class="inline-flex items-center justify-center gap-2 px-4 py-2 rounded-lg bg-slate-800 text-white font-semibold hover:bg-slate-700 transition-colors">
+                <i class="fas fa-link"></i>
+                <span>Paste invite link</span>
+            </a>
         </div>
     </section>
 

--- a/pickem/pickem_homepage/tests.py
+++ b/pickem/pickem_homepage/tests.py
@@ -4205,7 +4205,7 @@ class FamilyAdminExperienceTests(TestCase):
             "code_hash": hash_invite_code(raw_code),
             "role": FamilyMembership.Role.MEMBER,
             "expires_at": timezone.now() + timedelta(days=14),
-            "max_uses": 20,
+            "max_uses": 1,
             "use_count": 1,
             "created_by": self.owner,
         }
@@ -4814,15 +4814,16 @@ class FamilyAdminExperienceTests(TestCase):
             role=FamilyMembership.Role.MEMBER,
             recipient_email="target@example.com",
             use_count=3,
-            max_uses=10,
+            max_uses=1,
         )
         current_invite.is_revoked = True
         current_invite.save(update_fields=["is_revoked", "updated_at"])
         self._admin_invitation(
             raw_code="OPEN-INVITE-CODE",
             role=FamilyMembership.Role.MEMBER,
+            recipient_email="pending@example.com",
             use_count=0,
-            max_uses=5,
+            max_uses=1,
         )
         self._admin_invitation(
             raw_code="OTHER-FAMILY-CODE",
@@ -4838,19 +4839,19 @@ class FamilyAdminExperienceTests(TestCase):
         self.assertTemplateUsed(response, "pickem/family_admin_invites.html")
         self.assertContains(response, "Smith Family")
         self.assertContains(response, "Member")
-        self.assertContains(response, "10")
-        self.assertContains(response, "3")
+        self.assertContains(response, "Yes")
+        self.assertContains(response, "No")
         self.assertContains(response, "target@example.com")
         self.assertContains(response, "admin-owner")
         self.assertContains(response, "Revoked")
         self.assertContains(response, str(current_invite.id))
-        self.assertContains(response, "Anyone with link")
+        self.assertContains(response, "pending@example.com")
         self.assertNotContains(response, "SAFE-LIST-CODE")
         self.assertNotContains(response, current_invite.code_hash)
         self.assertNotContains(response, "OTHER-FAMILY-CODE")
         self.assertNotContains(response, "Jones Family")
 
-    def test_admin_and_owner_can_create_member_invites_with_one_time_raw_display(self):
+    def test_admin_and_owner_can_create_member_invites_with_one_time_link_display(self):
         for user in (self.owner, self.admin_user):
             with self.subTest(user=user.username):
                 self.client.force_login(user)
@@ -4862,7 +4863,6 @@ class FamilyAdminExperienceTests(TestCase):
                         "role": FamilyMembership.Role.MEMBER,
                         "recipient_email": " TargetUser@Example.com ",
                         "expires_in_days": "21",
-                        "max_uses": "7",
                     },
                 )
 
@@ -4872,20 +4872,19 @@ class FamilyAdminExperienceTests(TestCase):
                     family=self.family,
                     created_by=user,
                 ).latest("created_at")
-                raw_code = response.context["invite_code"]
+                invite_link = response.context["invite_link"]
                 self.assertEqual(
                     FamilyInvitation.objects.filter(family=self.family).count(),
                     before_count + 1,
                 )
                 self.assertEqual(invitation.role, FamilyMembership.Role.MEMBER)
                 self.assertEqual(invitation.recipient_email, "targetuser@example.com")
-                self.assertEqual(invitation.max_uses, 7)
+                self.assertEqual(invitation.max_uses, 1)
                 self.assertEqual(invitation.use_count, 0)
                 self.assertFalse(invitation.is_revoked)
                 self.assertTrue(invitation.code_hash.startswith("sha256:"))
-                self.assertNotEqual(invitation.code_hash, raw_code)
-                self.assertContains(response, raw_code)
-                self.assertContains(response, reverse("accept_invite_link", kwargs={"invite_code": raw_code}))
+                self.assertContains(response, invite_link)
+                self.assertIn("/invites/", invite_link)
                 audit = FamilyAuditLog.objects.get(
                     family=self.family,
                     actor=user,
@@ -4893,10 +4892,10 @@ class FamilyAdminExperienceTests(TestCase):
                     target_id=str(invitation.id),
                 )
                 self.assertEqual(audit.metadata["recipient_email"], "targetuser@example.com")
-                self.assertNotIn(raw_code, str(audit.metadata))
+                self.assertNotIn(invite_link, str(audit.metadata))
 
                 reload_response = self.client.get(self._invites_url())
-                self.assertNotContains(reload_response, raw_code)
+                self.assertNotContains(reload_response, invite_link)
                 self.assertNotContains(reload_response, invitation.code_hash)
 
     @patch("pickem_homepage.views.transaction.on_commit", side_effect=lambda callback: callback())
@@ -4916,7 +4915,6 @@ class FamilyAdminExperienceTests(TestCase):
                 "role": FamilyMembership.Role.MEMBER,
                 "recipient_email": "target@example.com",
                 "expires_in_days": "14",
-                "max_uses": "5",
             },
         )
 
@@ -4945,14 +4943,13 @@ class FamilyAdminExperienceTests(TestCase):
                 "role": FamilyMembership.Role.MEMBER,
                 "recipient_email": "target@example.com",
                 "expires_in_days": "14",
-                "max_uses": "5",
             },
         )
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(
             response,
-            "Invite saved for target@example.com, but Resend is not configured yet so no email was sent.",
+            "Invite saved for target@example.com, but Resend is not configured yet so no email was sent. Use the invite link below.",
         )
         configured_mock.assert_called_once_with()
         send_mock.assert_not_called()
@@ -4972,7 +4969,7 @@ class FamilyAdminExperienceTests(TestCase):
         response = self.client.post(self._invite_replace_url(invite))
 
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "Invite replaced. Copy the new code now.")
+        self.assertContains(response, "Invite replaced. Share the new invite link now.")
         self.assertContains(response, "Invite email will be sent to target@example.com.")
         configured_mock.assert_called_once_with()
         on_commit_mock.assert_called_once()
@@ -4997,7 +4994,7 @@ class FamilyAdminExperienceTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(
             response,
-            "Invite saved for target@example.com, but Resend is not configured yet so no email was sent.",
+            "Invite saved for target@example.com, but Resend is not configured yet so no email was sent. Use the invite link below.",
         )
         configured_mock.assert_called_once_with()
         send_mock.assert_not_called()
@@ -5010,7 +5007,7 @@ class FamilyAdminExperienceTests(TestCase):
             {
                 "role": FamilyMembership.Role.ADMIN,
                 "expires_in_days": "14",
-                "max_uses": "5",
+                "recipient_email": "admin-target@example.com",
             },
         )
 
@@ -5028,7 +5025,7 @@ class FamilyAdminExperienceTests(TestCase):
             {
                 "role": FamilyMembership.Role.ADMIN,
                 "expires_in_days": "14",
-                "max_uses": "5",
+                "recipient_email": "admin-target@example.com",
             },
         )
 
@@ -5070,10 +5067,9 @@ class FamilyAdminExperienceTests(TestCase):
             created_by=self.admin_user,
         )
         self.assertEqual(replacement.role, replacement_source.role)
-        self.assertEqual(replacement.max_uses, replacement_source.max_uses)
-        raw_code = replace_response.context["invite_code"]
-        self.assertContains(replace_response, raw_code)
-        self.assertNotIn(raw_code, str(FamilyAuditLog.objects.filter(
+        self.assertEqual(replacement.max_uses, 1)
+        self.assertContains(replace_response, replace_response.context["invite_link"])
+        self.assertNotIn("REPLACE-ME", str(FamilyAuditLog.objects.filter(
             family=self.family,
             target_id=str(replacement.id),
         ).values_list("metadata", flat=True)))
@@ -5124,7 +5120,7 @@ class FamilyAdminExperienceTests(TestCase):
                     {
                         "role": FamilyMembership.Role.MEMBER,
                         "expires_in_days": "14",
-                        "max_uses": "5",
+                        "recipient_email": "blocked@example.com",
                     },
                 )
                 revoke_response = self.client.post(self._invite_revoke_url(invite))
@@ -5148,7 +5144,7 @@ class FamilyAdminExperienceTests(TestCase):
             {
                 "role": FamilyMembership.Role.MEMBER,
                 "expires_in_days": "14",
-                "max_uses": "5",
+                "recipient_email": "blocked@example.com",
             },
         )
         csrf_revoke = csrf_client.post(self._invite_revoke_url(invite))
@@ -5949,7 +5945,7 @@ class InviteFlowTests(TestCase):
             "code_hash": self._hash_code(raw_code),
             "role": FamilyMembership.Role.MEMBER,
             "expires_at": timezone.now() + timedelta(days=14),
-            "max_uses": 20,
+            "max_uses": 1,
             "created_by": self.owner,
         }
         defaults.update(overrides)
@@ -5962,27 +5958,22 @@ class InviteFlowTests(TestCase):
         response = self.client.post(self._create_invite_url())
 
         invitation = FamilyInvitation.objects.get(family=self.family)
-        raw_code = response.context["invite_code"]
+        invite_link = response.context["invite_link"]
 
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "pickem/family_pool_home.html")
         self.assertEqual(invitation.pool, self.pool)
         self.assertEqual(invitation.role, FamilyMembership.Role.MEMBER)
-        self.assertEqual(invitation.max_uses, 20)
+        self.assertEqual(invitation.max_uses, 1)
         self.assertEqual(invitation.use_count, 0)
         self.assertFalse(invitation.is_revoked)
         self.assertGreaterEqual(invitation.expires_at, before + timedelta(days=13, hours=23))
         self.assertLessEqual(invitation.expires_at, timezone.now() + timedelta(days=14, minutes=1))
         self.assertTrue(invitation.code_hash.startswith("sha256:"))
-        self.assertNotEqual(invitation.code_hash, raw_code)
-        self.assertFalse(
-            FamilyInvitation.objects.filter(code_hash__icontains=raw_code).exists()
-        )
         self.assertFalse(hasattr(invitation, "code"))
         self.assertFalse(hasattr(invitation, "raw_code"))
-        self.assertGreaterEqual(len(raw_code), 32)
-        self.assertContains(response, raw_code)
-        self.assertContains(response, self._link_url(raw_code))
+        self.assertIn("/invites/", invite_link)
+        self.assertContains(response, invite_link)
         self.assertTrue(
             FamilyAuditLog.objects.filter(
                 family=self.family,
@@ -5997,7 +5988,7 @@ class InviteFlowTests(TestCase):
             action=FamilyAuditLog.Action.INVITATION_CREATED,
             target_id=str(invitation.id),
         )
-        self.assertNotIn(raw_code, str(audit.metadata))
+        self.assertNotIn(invite_link, str(audit.metadata))
 
     def test_non_owners_cannot_create_phase_three_invites(self):
         for user, expected_status in [
@@ -6058,7 +6049,7 @@ class InviteFlowTests(TestCase):
             ).exists()
         )
 
-    def test_link_acceptance_requires_login_and_accepts_by_post(self):
+    def test_link_acceptance_requires_login_and_accepts_on_get(self):
         self._invitation(raw_code="link-code")
 
         anonymous = self.client.get(self._link_url("link-code"))
@@ -6068,12 +6059,9 @@ class InviteFlowTests(TestCase):
         self.client.force_login(self.joiner)
 
         get_response = self.client.get(self._link_url("link-code"))
-        post_response = self.client.post(self._link_url("link-code"))
 
-        self.assertEqual(get_response.status_code, 200)
-        self.assertTemplateUsed(get_response, "pickem/join_family.html")
         self.assertRedirects(
-            post_response,
+            get_response,
             reverse(
                 "family_pool_home",
                 kwargs={"family_slug": self.family.slug, "pool_slug": self.pool.slug},
@@ -6107,6 +6095,23 @@ class InviteFlowTests(TestCase):
                 status=FamilyMembership.Status.ACTIVE,
             ).exists()
         )
+        self.assertEqual(invite.use_count, 1)
+
+    def test_join_family_accepts_full_invite_link_pasted_into_form(self):
+        invite = self._invitation(
+            raw_code="paste-link-code",
+            recipient_email="joiner@example.com",
+            use_count=0,
+        )
+        self.client.force_login(self.joiner)
+
+        response = self.client.post(
+            self._join_url(),
+            {"code": "https://family-pickem.com/invites/paste-link-code/"},
+        )
+
+        invite.refresh_from_db()
+        self.assertEqual(response.status_code, 302)
         self.assertEqual(invite.use_count, 1)
 
     def test_email_targeted_invite_rejects_wrong_account_without_mutation(self):
@@ -6231,7 +6236,7 @@ class InviteFlowTests(TestCase):
 
                 self.assertEqual(response.status_code, 200)
                 self.assertTemplateUsed(response, "pickem/join_family.html")
-                self.assertContains(response, "Invite code is invalid or unavailable.")
+                self.assertContains(response, "This invitation is invalid or unavailable.")
                 self.assertNotContains(response, "Smith Family")
                 self.assertNotContains(response, "Inactive Family")
                 self.assertNotContains(response, "Other Family")

--- a/pickem/pickem_homepage/views.py
+++ b/pickem/pickem_homepage/views.py
@@ -35,6 +35,7 @@ from django.contrib import messages
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import never_cache
 from functools import wraps
+from urllib.parse import parse_qs, urlparse
 # from django_ratelimit.decorators import ratelimit  # Disabled for now
 from collections import defaultdict
 import hashlib
@@ -337,9 +338,17 @@ def generate_unique_slug(model, value, *, scoped_filters=None, max_length=80):
 
 
 def normalize_invite_code(raw_code):
+    raw_code = (raw_code or '').strip()
+    if raw_code.startswith(('http://', 'https://')):
+        parsed = urlparse(raw_code)
+        path = parsed.path.rstrip('/')
+        if '/invites/' in path:
+            raw_code = path.rsplit('/invites/', 1)[-1].strip('/')
+        else:
+            raw_code = parse_qs(parsed.query).get('code', [raw_code])[0]
     return ''.join(
         char.lower()
-        for char in (raw_code or '').strip()
+        for char in raw_code
         if char.isalnum()
     )
 
@@ -623,7 +632,7 @@ def pool_entries_locked(pool):
 
 
 def accept_invitation_for_user(request, raw_code):
-    """Redeem an invite code. Returns (invitation, pool, membership, error) —
+    """Redeem an invite token. Returns (invitation, pool, membership, error) —
     the first three are None on failure, and error carries a user-facing
     message only when the failure deserves a specific explanation."""
     with transaction.atomic():
@@ -698,7 +707,7 @@ def accept_invitation_for_user(request, raw_code):
 def render_invalid_invite(request, form=None, *, invite_code='', message=None):
     if form is None:
         form = JoinFamilyForm(initial={'code': invite_code} if invite_code else None)
-    form.add_error('code', message or "Invite code is invalid or unavailable.")
+    form.add_error('code', message or "This invitation is invalid or unavailable.")
     return render(request, 'pickem/join_family.html', {
         'form': form,
         'invite_code': invite_code,
@@ -822,31 +831,17 @@ def join_family(request):
 
 @login_required
 def accept_invite_link(request, invite_code):
-    form = JoinFamilyForm(
-        initial={'code': invite_code},
-        data={'code': invite_code} if request.method == 'POST' else None,
-    )
-
-    if request.method == 'POST' and form.is_valid():
-        invitation, pool, _membership, error = accept_invitation_for_user(
-            request,
-            form.cleaned_data['code'],
+    invitation, pool, _membership, error = accept_invitation_for_user(request, invite_code)
+    if invitation:
+        messages.success(request, f"You joined {invitation.family.name}.")
+        return redirect(
+            'family_pool_home',
+            family_slug=invitation.family.slug,
+            pool_slug=pool.slug,
         )
-        if invitation:
-            messages.success(request, f"You joined {invitation.family.name}.")
-            return redirect(
-                'family_pool_home',
-                family_slug=invitation.family.slug,
-                pool_slug=pool.slug,
-            )
-        return render_invalid_invite(request, form, invite_code=invite_code, message=error)
 
-    context = {
-        'form': form,
-        'invite_code': invite_code,
-        'gameseason': get_season(),
-    }
-    return render(request, 'pickem/join_family.html', context)
+    form = JoinFamilyForm(initial={'code': invite_code})
+    return render_invalid_invite(request, form, invite_code=invite_code, message=error)
 
 
 @require_http_methods(["POST"])
@@ -862,7 +857,7 @@ def create_family_invite(request, family_slug, pool_slug):
             code_hash=hash_invite_code(raw_code),
             role=FamilyMembership.Role.MEMBER,
             expires_at=timezone.now() + timedelta(days=14),
-            max_uses=20,
+            max_uses=1,
             created_by=request.user,
         )
         FamilyAuditLog.objects.create(
@@ -884,13 +879,12 @@ def create_family_invite(request, family_slug, pool_slug):
         'family': tenant_context.family,
         'pool': tenant_context.pool,
         'membership': tenant_context.membership,
-        'invite_code': raw_code,
         'invite_link': request.build_absolute_uri(
             reverse('accept_invite_link', kwargs={'invite_code': raw_code})
         ),
         'gameseason': get_season(),
     }
-    messages.success(request, "Invite created. Copy it now; it will not be shown again.")
+    messages.success(request, "Invite created. Share the invite link now; it will not be shown again.")
     return render(request, 'pickem/family_pool_home.html', context)
 
 
@@ -1954,9 +1948,6 @@ def build_invite_audit_metadata(invitation, *, source, replacement_for=None):
 
 
 def handle_targeted_invite_email_feedback(request, *, invitation, raw_code):
-    if not invitation.recipient_email:
-        return
-
     invite_link = request.build_absolute_uri(
         reverse('accept_invite_link', kwargs={'invite_code': raw_code})
     )
@@ -1977,7 +1968,7 @@ def handle_targeted_invite_email_feedback(request, *, invitation, raw_code):
             request,
             (
                 f"Invite saved for {invitation.recipient_email}, but Resend is not "
-                "configured yet so no email was sent."
+                "configured yet so no email was sent. Use the invite link below."
             ),
         )
 
@@ -1990,7 +1981,6 @@ def create_admin_invitation(
     role,
     recipient_email,
     expires_in_days,
-    max_uses,
     request,
     replacement_for=None,
 ):
@@ -2002,7 +1992,7 @@ def create_admin_invitation(
         recipient_email=recipient_email or None,
         role=role,
         expires_at=timezone.now() + timedelta(days=expires_in_days),
-        max_uses=max_uses,
+        max_uses=1,
         created_by=actor,
     )
     FamilyAuditLog.objects.create(
@@ -2037,7 +2027,6 @@ def render_family_admin_invites(request, tenant_context, form, *, invite_code=No
         'gameseason': pool.season or get_season(),
         'form': form,
         'invitations': invitations,
-        'invite_code': invite_code,
         'invite_link': invite_link,
         'can_create_admin_invites': (
             tenant_context.membership.role == FamilyMembership.Role.OWNER
@@ -2057,7 +2046,6 @@ def family_pool_admin_invites(request, family_slug, pool_slug):
         initial={
             'role': FamilyMembership.Role.MEMBER,
             'expires_in_days': 14,
-            'max_uses': 20,
         },
     )
 
@@ -2078,11 +2066,10 @@ def family_pool_admin_invites(request, family_slug, pool_slug):
                 role=form.cleaned_data['role'],
                 recipient_email=form.cleaned_data['recipient_email'],
                 expires_in_days=form.cleaned_data['expires_in_days'],
-                max_uses=form.cleaned_data['max_uses'],
                 request=request,
             )
 
-        messages.success(request, "Invite created. Copy it now; it will not be shown again.")
+        messages.success(request, "Invite created. Share the invite link now; it will not be shown again.")
         handle_targeted_invite_email_feedback(
             request,
             invitation=invitation,
@@ -2092,7 +2079,6 @@ def family_pool_admin_invites(request, family_slug, pool_slug):
             request,
             tenant_context,
             form,
-            invite_code=raw_code,
             invite_link=request.build_absolute_uri(
                 reverse('accept_invite_link', kwargs={'invite_code': raw_code})
             ),
@@ -2173,7 +2159,6 @@ def family_pool_admin_invite_replace(request, family_slug, pool_slug, invitation
             role=old_invitation.role,
             recipient_email=old_invitation.recipient_email,
             expires_in_days=14,
-            max_uses=old_invitation.max_uses or 20,
             request=request,
             replacement_for=old_invitation.id,
         )
@@ -2184,7 +2169,6 @@ def family_pool_admin_invite_replace(request, family_slug, pool_slug, invitation
         initial={
             'role': FamilyMembership.Role.MEMBER,
             'expires_in_days': 14,
-            'max_uses': 20,
         },
     )
     handle_targeted_invite_email_feedback(
@@ -2192,12 +2176,11 @@ def family_pool_admin_invite_replace(request, family_slug, pool_slug, invitation
         invitation=new_invitation,
         raw_code=raw_code,
     )
-    messages.success(request, "Invite replaced. Copy the new code now.")
+    messages.success(request, "Invite replaced. Share the new invite link now.")
     return render_family_admin_invites(
         request,
         tenant_context,
         form,
-        invite_code=raw_code,
         invite_link=request.build_absolute_uri(
             reverse('accept_invite_link', kwargs={'invite_code': raw_code})
         ),

--- a/pickem/pickem_superadmin/tests/test_email.py
+++ b/pickem/pickem_superadmin/tests/test_email.py
@@ -207,6 +207,8 @@ class InviteEmailSendingTests(TestCase):
         self.assertEqual(params['reply_to'], 'reply@family-pickem.com')
         self.assertEqual(params['to'], ['target@example.com'])
         self.assertIn('https://family-pickem.com/invite/abc123', params['html'])
+        self.assertNotIn('Fallback invite code', params['html'])
+        self.assertNotIn('Fallback invite code', params['text'])
 
     def test_send_family_invitation_email_skips_when_not_configured(self):
         result = send_family_invitation_email(


### PR DESCRIPTION
## Summary
- make family invites one-time, email-targeted links
- remove user-facing max-use / raw-code concepts from the invite UI and emails
- auto-accept tokenized invite links after login and allow pasting a full invite link into the join form

## Verification
- `DJANGO_SETTINGS_MODULE=pickem.test_settings python manage.py test pickem_homepage.tests.FamilyAdminExperienceTests pickem_homepage.tests.InviteFlowTests pickem_superadmin.tests.test_email`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Family invitations now use single-use links tied to a specific recipient email.
  - Invite links can be entered as full URLs or codes.
  - Invite expiration can be set from 1–365 days, defaulting to 14.

- **Improvements**
  - Updated invite creation, history, onboarding, and joining interfaces to use invitation links.
  - Invitation emails and screens no longer display fallback invite codes.
  - Invite history now shows recipient and acceptance status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->