### PR TITLE
fix(picks): stop 404ing superusers on the picks page in their own family

### DIFF
--- a/pickem/pickem_homepage/tests.py
+++ b/pickem/pickem_homepage/tests.py
@@ -1727,6 +1727,68 @@ class TenantPickFlowIsolationTests(TestCase):
         )
 
 
+class HasRealFamilyMembershipTests(TestCase):
+    """Regression guard for the picks-page 404 (#61 gate + superuser synthetic
+    membership): a superuser is handed a synthetic, never-saved owner membership
+    (no pk) for god-mode oversight, even in families where they hold a real row.
+    has_real_family_membership must still recognise them as a real participant
+    there, or submitting picks 404s for a superuser in their own family."""
+
+    def setUp(self):
+        self.family = Family.objects.create(name='Daghouse', slug='daghouse')
+        self.superuser = User.objects.create_superuser(
+            username='root', email='root@example.com', password='pw',
+        )
+        self.member = User.objects.create_user(
+            username='mem', email='mem@example.com', password='pw',
+        )
+
+    def _synthetic(self, user):
+        # Mirrors authz._superuser_membership: constructed, never saved -> pk None.
+        return FamilyMembership(
+            family=self.family, user=user,
+            role=FamilyMembership.Role.OWNER,
+            status=FamilyMembership.Status.ACTIVE,
+        )
+
+    def test_saved_membership_is_real(self):
+        from pickem_homepage.views import has_real_family_membership
+
+        membership = FamilyMembership.objects.create(
+            family=self.family, user=self.member,
+            role=FamilyMembership.Role.MEMBER,
+            status=FamilyMembership.Status.ACTIVE,
+        )
+        self.assertTrue(has_real_family_membership(membership))
+
+    def test_synthetic_membership_counts_when_a_real_active_row_exists(self):
+        from pickem_homepage.views import has_real_family_membership
+
+        FamilyMembership.objects.create(
+            family=self.family, user=self.superuser,
+            role=FamilyMembership.Role.OWNER,
+            status=FamilyMembership.Status.ACTIVE,
+        )
+        synthetic = self._synthetic(self.superuser)
+        self.assertIsNone(synthetic.pk)
+        self.assertTrue(has_real_family_membership(synthetic))
+
+    def test_synthetic_membership_is_not_real_without_a_row(self):
+        from pickem_homepage.views import has_real_family_membership
+
+        self.assertFalse(has_real_family_membership(self._synthetic(self.superuser)))
+
+    def test_inactive_real_row_does_not_count_for_synthetic(self):
+        from pickem_homepage.views import has_real_family_membership
+
+        FamilyMembership.objects.create(
+            family=self.family, user=self.superuser,
+            role=FamilyMembership.Role.OWNER,
+            status=FamilyMembership.Status.INACTIVE,
+        )
+        self.assertFalse(has_real_family_membership(self._synthetic(self.superuser)))
+
+
 class TenantScoresStandingsRulesIsolationTests(TestCase):
     @classmethod
     def setUpTestData(cls):

--- a/pickem/pickem_homepage/views.py
+++ b/pickem/pickem_homepage/views.py
@@ -320,7 +320,26 @@ def default_pool_name(*, season, competition='nfl'):
 
 
 def has_real_family_membership(membership):
-    return bool(getattr(membership, 'pk', None))
+    """Is this user a genuine participant in the membership's family?
+
+    A saved membership (has a pk) is real. Superusers, though, are handed a
+    synthetic never-saved owner membership for god-mode oversight (see
+    require_family_membership) — it has no pk even in families where they hold
+    a real row. So when there's no pk, fall back to checking for an actual
+    active membership before rejecting: otherwise participant-only pages (like
+    submitting picks) would 404 for a superuser in their own family.
+    """
+    if getattr(membership, 'pk', None):
+        return True
+    user = getattr(membership, 'user', None)
+    family = getattr(membership, 'family', None)
+    if user is None or family is None:
+        return False
+    return FamilyMembership.objects.filter(
+        user=user,
+        family=family,
+        status=FamilyMembership.Status.ACTIVE,
+    ).exists()
 
 
 def generate_unique_slug(model, value, *, scoped_filters=None, max_length=80):


### PR DESCRIPTION
## Bug
Submitting picks 404s for superusers, e.g. `/families/legacy-family-league/pools/pickem-pool/picks/` → "Not Found" — even in a family where the superuser is a real active member.

## Root cause
`#61` added a `has_real_family_membership` gate to the picks submit/edit pages (participant-only). But `require_family_membership` (authz) returns a **synthetic, never-saved owner membership** for every superuser (god-mode oversight), which has **no `pk`** even in families where they hold a real membership row. The gate checked only `membership.pk`, so it rejected every superuser → 404 on picks in every family, including their own.

## Fix
`has_real_family_membership` now, when the membership has no `pk`, falls back to checking for an actual **active** `FamilyMembership` row for that user+family before rejecting. Behaviour:
- Normal members (real saved membership): unchanged.
- Superusers who are **real** members: now recognised → picks works.
- Superusers who are **not** members: still 404 (correctly, they aren't participants).
- Inactive memberships: still don't count.

No change to god-mode admin authz (the synthetic owner membership is untouched everywhere else).

## Tests
Added `HasRealFamilyMembershipTests` (4 cases: saved, synthetic-with-real-active-row, synthetic-without-row, synthetic-with-inactive-row). All 22 existing `TenantPickFlowIsolationTests` still pass. Verified under `--settings=pickem.test_settings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved membership validation so access is recognized only when a saved or active membership exists.
  * Prevented unsaved or synthetic memberships from being treated as valid when required details are missing or no active membership is available.
* **Tests**
  * Added coverage for saved, active, inactive, missing, and synthetic membership scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->