### PR TITLE
fix(email): brand invite emails + close an HTML-injection hole

### DIFF
--- a/pickem/pickem/settings.py
+++ b/pickem/pickem/settings.py
@@ -227,6 +227,12 @@ LOGOUT_REDIRECT_URL = '/'
 RESEND_API_KEY = os.environ.get('RESEND_API_KEY', '').strip()
 RESEND_FROM_EMAIL = os.environ.get('RESEND_FROM_EMAIL', '').strip()
 RESEND_INVITE_REPLY_TO = os.environ.get('RESEND_INVITE_REPLY_TO', '').strip()
+# Absolute, publicly-reachable URL to the logo shown in invite emails. Left blank
+# by default because production static is served from S3 (URLs can be signed and
+# expire, which would break the image in delivered mail); the invite template
+# falls back to a styled text wordmark when this is empty. Point it at a stable
+# public logo URL to show the image.
+INVITE_EMAIL_LOGO_URL = os.environ.get('INVITE_EMAIL_LOGO_URL', '').strip()
 
 # Internationalization
 # https://docs.djangoproject.com/en/3.0/topics/i18n/

--- a/pickem/pickem_homepage/emailing.py
+++ b/pickem/pickem_homepage/emailing.py
@@ -1,6 +1,8 @@
 import logging
 
 from django.conf import settings
+from django.template.loader import render_to_string
+
 from pickem_superadmin.models import EmailProviderSettings
 
 try:
@@ -62,21 +64,21 @@ def send_family_invitation_email(*, invitation, invite_link, invite_code):
 
     resend.api_key = config['api_key']
     pool_name = invitation.pool.name if invitation.pool else "Family Pick'em"
+    # Render from templates: Django auto-escapes the HTML context (family/pool
+    # names are user-controlled, so building the HTML by hand would be an
+    # injection hole) and keeps the branding in one place.
+    email_context = {
+        'family_name': invitation.family.name,
+        'pool_name': pool_name,
+        'invite_link': invite_link,
+        'logo_url': getattr(settings, 'INVITE_EMAIL_LOGO_URL', ''),
+    }
     params = {
         'from': config['from_email'],
         'to': [recipient_email],
         'subject': f"You're invited to join {invitation.family.name} on Family Pick'em",
-        'html': (
-            f"<p>You have been invited to join <strong>{invitation.family.name}</strong>"
-            f" in <strong>{pool_name}</strong>.</p>"
-            f"<p><a href=\"{invite_link}\">Accept your invite</a></p>"
-            f"<p>If the button does not work, use this invite link:</p>"
-            f"<p>{invite_link}</p>"
-        ),
-        'text': (
-            f"You have been invited to join {invitation.family.name} on Family Pick'em.\n\n"
-            f"Accept your invite: {invite_link}"
-        ),
+        'html': render_to_string('emails/family_invite.html', email_context),
+        'text': render_to_string('emails/family_invite.txt', email_context),
     }
     if config['reply_to']:
         params['reply_to'] = config['reply_to']
@@ -117,12 +119,16 @@ def send_test_email(*, to_email):
     params = {
         'from': config['from_email'],
         'to': [to_email],
-        'subject': 'Family Pickem email configuration test',
+        'subject': "Family Pick'em email configuration test",
         'html': (
-            '<p>This is a test email from Family Pickem.</p>'
-            '<p>Your Resend configuration is working.</p>'
+            '<div style="font-family:\'Segoe UI\',Helvetica,Arial,sans-serif; max-width:480px; margin:0 auto;">'
+            '<div style="background:#0B3D91; color:#fff; padding:20px 24px; border-radius:12px 12px 0 0; font-weight:800; font-size:18px;">🏈 Family Pick&rsquo;em</div>'
+            '<div style="border:1px solid #eef1f5; border-top:0; border-radius:0 0 12px 12px; padding:24px;">'
+            '<p style="margin:0 0 8px; font-size:16px; color:#111827;">Your Resend email configuration is working. ✅</p>'
+            '<p style="margin:0; font-size:14px; color:#6b7280;">This is a test message sent from the Family Pick&rsquo;em superadmin console.</p>'
+            '</div></div>'
         ),
-        'text': 'This is a test email from Family Pickem. Your Resend configuration is working.',
+        'text': "Family Pick'em: your Resend email configuration is working. This is a test message from the superadmin console.",
     }
     if config['reply_to']:
         params['reply_to'] = config['reply_to']

--- a/pickem/pickem_homepage/templates/emails/family_invite.html
+++ b/pickem/pickem_homepage/templates/emails/family_invite.html
@@ -1,0 +1,54 @@
+{% autoescape on %}<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>You're invited to {{ family_name }}</title>
+</head>
+<body style="margin:0; padding:0; background:#eef1f5; font-family:'Segoe UI',Helvetica,Arial,sans-serif; color:#1f2937;">
+  <!-- Email clients need table layout + inline styles; keep this self-contained. -->
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#eef1f5; padding:24px 0;">
+    <tr>
+      <td align="center">
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:560px; background:#ffffff; border-radius:14px; overflow:hidden; box-shadow:0 1px 3px rgba(16,24,40,0.08);">
+          <!-- Header -->
+          <tr>
+            <td style="background:#0B3D91; padding:28px 32px; text-align:center;">
+              {% if logo_url %}<img src="{{ logo_url }}" alt="Family Pick'em" height="40" style="height:40px; width:auto; display:inline-block;">{% else %}<span style="color:#ffffff; font-size:22px; font-weight:800;">Family Pick'em</span>{% endif %}
+            </td>
+          </tr>
+          <!-- Body -->
+          <tr>
+            <td style="padding:36px 32px 8px;">
+              <p style="margin:0 0 6px; font-size:13px; text-transform:uppercase; letter-spacing:0.08em; color:#0B3D91; font-weight:700;">🏈 You're invited</p>
+              <h1 style="margin:0 0 16px; font-size:24px; line-height:1.25; color:#111827;">Join {{ family_name }} on Family&nbsp;Pick'em</h1>
+              <p style="margin:0 0 24px; font-size:16px; line-height:1.6; color:#4b5563;">
+                You've been invited to play in <strong>{{ pool_name }}</strong>. Pick game winners each week, climb the leaderboard, and settle who really knows football.
+              </p>
+              <!-- Bulletproof CTA button -->
+              <table role="presentation" cellpadding="0" cellspacing="0" style="margin:0 0 24px;">
+                <tr>
+                  <td align="center" bgcolor="#0B3D91" style="border-radius:10px;">
+                    <a href="{{ invite_link }}" style="display:inline-block; padding:14px 28px; font-size:16px; font-weight:600; color:#ffffff; text-decoration:none; border-radius:10px;">Accept your invite</a>
+                  </td>
+                </tr>
+              </table>
+              <p style="margin:0 0 6px; font-size:13px; color:#6b7280;">If the button doesn't work, copy and paste this link:</p>
+              <p style="margin:0 0 8px; font-size:13px; word-break:break-all;"><a href="{{ invite_link }}" style="color:#0B3D91;">{{ invite_link }}</a></p>
+            </td>
+          </tr>
+          <!-- Footer -->
+          <tr>
+            <td style="padding:20px 32px 28px; border-top:1px solid #eef1f5;">
+              <p style="margin:0; font-size:12px; line-height:1.5; color:#98a2b3;">
+                You received this because someone invited you to a Family Pick'em league. If you weren't expecting it, you can safely ignore this email.
+              </p>
+            </td>
+          </tr>
+        </table>
+        <p style="max-width:560px; margin:16px auto 0; font-size:12px; color:#98a2b3; text-align:center;">Family Pick'em &middot; Your NFL pick'em league</p>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>{% endautoescape %}

--- a/pickem/pickem_homepage/templates/emails/family_invite.txt
+++ b/pickem/pickem_homepage/templates/emails/family_invite.txt
@@ -1,0 +1,12 @@
+{% autoescape off %}You're invited to join {{ family_name }} on Family Pick'em!
+
+You've been invited to play in {{ pool_name }}. Pick game winners each week,
+climb the leaderboard, and settle who really knows football.
+
+Accept your invite:
+{{ invite_link }}
+
+If you weren't expecting this, you can safely ignore this email.
+
+— Family Pick'em
+{% endautoescape %}

--- a/pickem/pickem_superadmin/tests/test_email.py
+++ b/pickem/pickem_superadmin/tests/test_email.py
@@ -210,6 +210,46 @@ class InviteEmailSendingTests(TestCase):
         self.assertNotIn('Fallback invite code', params['html'])
         self.assertNotIn('Fallback invite code', params['text'])
 
+    def test_invite_email_is_branded_and_escapes_html(self):
+        settings_obj = EmailProviderSettings.load()
+        settings_obj.invites_enabled = True
+        settings_obj.from_email = "Family Pick'em <invite@family-pickem.com>"
+        settings_obj.set_api_key('re_configured_secret')
+        settings_obj.save()
+
+        # A family name carrying HTML must never render unescaped into the email.
+        evil_family = Family.objects.create(name='<script>x</script>Crew', slug='evil')
+        evil_pool = Pool.objects.create(
+            family=evil_family, name='Pickem Pool', slug='pickem-pool', season=2627,
+        )
+        invitation = FamilyInvitation.objects.create(
+            family=evil_family, pool=evil_pool,
+            code_hash=hash_invite_code('xyz789'),
+            recipient_email='target@example.com',
+            role=FamilyMembership.Role.MEMBER, created_by=self.owner,
+        )
+
+        resend_mock = Mock()
+        resend_mock.Emails.send.return_value = {'id': 'email_456'}
+        with patch('pickem_homepage.emailing.resend', new=resend_mock):
+            send_family_invitation_email(
+                invitation=invitation,
+                invite_link='https://family-pickem.com/invite/xyz789',
+                invite_code='xyz789',
+            )
+        params = resend_mock.Emails.send.call_args.args[0]
+
+        # Escaping: the raw tag is gone, the escaped form is present.
+        self.assertNotIn('<script>x</script>', params['html'])
+        self.assertIn('&lt;script&gt;', params['html'])
+        # Branding: styled CTA, brand colour, and the wordmark are present.
+        self.assertIn('Accept your invite', params['html'])
+        self.assertIn('#0B3D91', params['html'])
+        self.assertIn("Family Pick'em", params['html'])
+        # Plain-text alternative carries the raw (unescaped) name and the link.
+        self.assertIn('<script>x</script>Crew', params['text'])
+        self.assertIn('https://family-pickem.com/invite/xyz789', params['text'])
+
     def test_send_family_invitation_email_skips_when_not_configured(self):
         result = send_family_invitation_email(
             invitation=self.invitation,
@@ -245,7 +285,7 @@ class InviteEmailSendingTests(TestCase):
         self.assertEqual(params['from'], 'Family Pickem <invite@family-pickem.com>')
         self.assertEqual(params['reply_to'], 'reply@family-pickem.com')
         self.assertEqual(params['to'], ['check@example.com'])
-        self.assertIn('Family Pickem email configuration test', params['subject'])
+        self.assertIn("Family Pick'em email configuration test", params['subject'])
 
     @patch.dict(
         'os.environ',


### PR DESCRIPTION
Review of the email-invite feature (#65/#67), with fixes. **The email code is ready to work the moment a Resend API key is configured** — no token needed to merge this.

## Issues found & fixed
1. **Not branded** (your question: they weren't). Invite emails were bare `<p>` tags with a plain link. Now rendered from `emails/family_invite.html` — navy branded header, logo (or text wordmark fallback), a styled CTA button, fallback link, and footer. Plain-text alternative too.
2. **HTML-injection**: the invite HTML was built with f-strings interpolating the **user-controlled** family/pool names and the link **unescaped**. A family name like `<script>…` would inject into the email. Rendering via a Django template auto-escapes it. Added a test proving the escape + branding.
3. Branded the config-test email and fixed the `Family Pickem` → `Family Pick'em` wordmark typo.

## Logo handling
`INVITE_EMAIL_LOGO_URL` setting (blank by default). Prod static is on S3 with signable URLs that can expire — bad for images in delivered mail — so the template falls back to a styled text wordmark unless you point this at a stable public logo URL.

## Reviewed and sound (no changes needed)
- `EmailProviderSettings`: API key is **encrypted at rest** (Fernet), masked for display, fails closed on bad ciphertext.
- Superadmin email settings view: gated, audited, and never puts the plaintext key in the audit diff.
- Invite form validates the recipient (`EmailField`); the send path degrades gracefully when Resend isn't configured (invite still saved, usable by link).

16 email tests pass under `--settings=pickem.test_settings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)