### PR TITLE
chore: remove dead xmlrpc Boolean import

### DIFF
--- a/pickem/pickem_api/models.py
+++ b/pickem/pickem_api/models.py
@@ -1,5 +1,4 @@
 import uuid
-from xmlrpc.client import Boolean
 from django.core.validators import MinValueValidator
 from django.db import models
 from django.contrib.auth.models import User


### PR DESCRIPTION
Removes an unused `from xmlrpc.client import Boolean` import in `pickem_api/models.py` (an IDE auto-import artifact; nothing references it). System check + `makemigrations --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)