### PR TITLE
test: end-to-end grading integration suite + Postgres CI workflow

### DIFF
--- a/.github/workflows/grading-integration-tests.yaml
+++ b/.github/workflows/grading-integration-tests.yaml
@@ -1,0 +1,63 @@
+name: Grading Integration Tests
+
+# End-to-end tests of the grading pipeline (grading_tests/) against
+# PostgreSQL — the production database engine. The regular PR job runs the
+# whole suite on SQLite; this one pins grading correctness (and the full
+# migration chain) on Postgres, and fails the PR on any regression.
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  grading_integration:
+    name: Grading pipeline on PostgreSQL
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: pickem_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_HOST: localhost
+      DATABASE_PORT: '5432'
+      DATABASE_NAME: pickem_test
+      DATABASE_USER: postgres
+      DATABASE_PASS: postgres
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: pip install -r pickem/requirements.txt
+
+      - name: Run migrations against PostgreSQL
+        # Validates the full migration chain on the production engine; the
+        # test runner below migrates its own test_* database independently.
+        run: cd pickem && python manage.py migrate --settings=pickem.test_settings_postgres
+
+      - name: Run grading integration tests
+        run: cd pickem && python manage.py test grading_tests --settings=pickem.test_settings_postgres --verbosity=2

--- a/docs/superpowers/specs/2026-07-16-grading-integration-tests-design.md
+++ b/docs/superpowers/specs/2026-07-16-grading-integration-tests-design.md
@@ -1,0 +1,101 @@
+# Grading Engine Integration Test Suite — Design
+
+**Date:** 2026-07-16
+**Status:** Approved for implementation (user supplied requirements; deviations from the
+original prompt are reconciled against the real codebase below)
+
+## Goal
+
+End-to-end integration tests that exercise the **real production grading pipeline** —
+not unit tests of the algorithm, and no duplicated grading logic in assertions. Tests
+create synthetic families, pools, users, games, and picks; populate final scores;
+run the actual management commands; and assert exact standings.
+
+## How grading actually works (ground truth)
+
+The production pipeline is `update_all`, which runs in dependency order:
+
+1. `update_records` / `update_games` — ESPN fetch (network; out of scope, replaced by
+   synthetic game data)
+2. `update_missed_picks` — applies each pool's `missed_pick_policy` (auto picks)
+3. `update_picks` — pool-agnostic: flags `pick_correct` where `pick == gameWinner`
+   (a team **slug**), marks games scored; real NFL ties are scored with no winner
+4. `update_standings` — per (pool, user): recomputes `week_N_points` from scored picks
+   using the pool's `win_points` / `tie_points`, folds in `week_N_bonus`
+5. `update_weekly_winners` — once every game of the week is finished+scored, runs the
+   pluggable tiebreaker engine (`pickem_api/weekly_winners.py`) per pool:
+   `primary_tiebreaker` → `secondary_tiebreaker` from `PoolSettings`; combined-yards
+   comes from an injectable `GameStatsProvider` (ESPN in prod)
+6. `update_rankings` — per-pool competition ranking (1, 1, 3, …) into `current_rank`
+7. `update_season_winners` / `update_stats` — season champion + per-user stats
+
+**Multi-tenancy:** games are global per (season, competition) — families share the NFL
+slate. Isolation lives in `GamePicks.pool`, `userSeasonPoints.pool`, and per-pool
+`PoolSettings`. The original prompt's "different games per family" doesn't exist in
+this schema; isolation tests assert pick/standings/rules isolation on a shared slate.
+
+**Spread pools:** `pick_type=against_spread` is a settings enum value that is locked in
+every form and has **no grading backend**. Spread scenarios cannot exercise real code
+today. Instead: one live "canary" test pins the current behavior (an against_spread
+pool still grades straight-up), and the four requested scenarios (favorite covers,
+favorite wins without covering, underdog outright, push) are committed as
+`@skip`-scaffolded tests with full expected standings, ready to enable when the
+backend lands. The canary fails loudly at that moment, forcing the scaffolds on.
+
+## Decisions
+
+- **Django `TestCase` over pytest.** The repo has ~9k lines of Django TestCase tests,
+  CI runs `manage.py test`, and there are zero test-only dependencies. Adding pytest
+  buys fixtures we don't need (factories cover it) at the cost of a second idiom.
+- **Hand-rolled factories over Factory Boy.** Same reasoning: `requirements.txt` is
+  also the production image's dependency set (no dev-requirements split), and the
+  factories needed are thin. `grading_tests/factories.py` provides Factory-Boy-style
+  sensible defaults + sequences without the dependency. If the suite outgrows this,
+  swapping to Factory Boy is mechanical.
+- **New top-level package `pickem/grading_tests/`** (unittest discovery picks it up in
+  the existing SQLite CI job automatically). Keeps the integration suite separate from
+  the per-app unit tests and lets the Postgres workflow target exactly this package.
+- **Real commands via `call_command`,** not direct service calls — the tests enter
+  through the same door production does. The only patch: the ESPN stats provider in
+  `update_weekly_winners` is replaced with a stub (the engine was explicitly designed
+  for injection). `--season` is always passed so `get_season()` never hits the API.
+- **Postgres in CI, SQLite locally.** New `pickem/pickem/test_settings_postgres.py`
+  (extends `test_settings`, env-driven DB) + a dedicated workflow with a `postgres:16`
+  service. The workflow also runs `manage.py migrate` against the service DB, so the
+  full migration chain is exercised on Postgres — something the SQLite job never did.
+
+## Layout
+
+```
+pickem/grading_tests/
+    __init__.py
+    README.md              # how to run, how to add a scenario
+    factories.py           # family/pool/user/membership/game/pick factories
+    harness.py             # pipeline runner, stub stats provider, standings asserts
+    test_straight_up.py    # scenario 1 (+ tie game, missed pick, idempotency)
+    test_tiebreakers.py    # scenarios 2–3 (primary, equidistant→secondary)
+    test_spread_pool.py    # scenario 4 (canary + skipped scaffolds)
+    test_tenant_isolation.py  # scenario 5
+    test_rule_config.py    # scenario 6 (points weights, chains, missed-pick policies)
+pickem/pickem/test_settings_postgres.py
+.github/workflows/grading-integration-tests.yaml
+```
+
+## Key harness pieces
+
+- `LeagueFixture` — one call creates Family + active Pool + PoolSettings (overridable)
+  + N users with active memberships.
+- `create_game(week, …)` / `finish_game(game, home, away)` — `finish_game` writes
+  exactly what `update_games` would (scores, `gameWinner` slug, `statusType=finished`),
+  so `update_picks` sees production-shaped data.
+- `run_grading_pipeline(season, yards=…)` — runs `update_missed_picks`,
+  `update_picks`, `update_standings`, `update_weekly_winners` (stubbed provider),
+  `update_rankings` in `update_all` order.
+- `assert_standings(pool, expected)` — exact-match on (user, weekly points, bonus,
+  total, rank) **and** on row count, so foreign rows in a pool fail the test.
+
+## Future scenarios (deliberately out of scope now)
+
+- `update_season_winners` end-of-season flag
+- `update_stats` accuracy/perfect-week integration
+- playoff weeks (`include_playoffs` is locked/unimplemented, same treatment as spread)

--- a/pickem/grading_tests/README.md
+++ b/pickem/grading_tests/README.md
@@ -1,0 +1,81 @@
+# Grading Integration Tests
+
+End-to-end tests of the **real production grading pipeline**. Every test
+creates synthetic families, pools, users, games, and picks; records final
+scores the way `update_games` would; runs the actual management commands;
+and asserts exact standings. No grading logic is duplicated in assertions.
+
+## Running
+
+```bash
+cd pickem
+
+# Fast local run (SQLite, same settings as the main CI job)
+python manage.py test grading_tests --settings=pickem.test_settings
+
+# Against PostgreSQL (what .github/workflows/grading-integration-tests.yaml runs)
+DATABASE_HOST=localhost DATABASE_PORT=5432 \
+DATABASE_NAME=pickem_test DATABASE_USER=postgres DATABASE_PASS=postgres \
+python manage.py test grading_tests --settings=pickem.test_settings_postgres
+```
+
+## How a scenario works
+
+```python
+class MyScenario(GradingTestCase):
+    def test_something(self):
+        league = create_league("alice", "bob", win_points=3)   # family+pool+users
+        game = create_game(1, mnf=True)                        # week 1, tiebreaker game
+        make_pick(league.pool, league["alice"], game, "home", score=45)
+        finish_game(game, 24, 21)                              # what update_games would write
+        self.run_pipeline(yards=700)                           # the real commands
+        self.assertStandings(league.pool, [(league["alice"], 3, 1), ...])
+```
+
+- `run_pipeline()` executes `update_missed_picks → update_picks →
+  update_standings → update_weekly_winners → update_rankings` — the grading
+  slice of production's `update_all`, in the same order. The two ESPN fetch
+  steps (`update_records`, `update_games`) are replaced by the factories;
+  the ESPN stats provider used by the combined-yards tiebreaker is stubbed
+  via the engine's injection point (`yards=` / `per_game_yards=`).
+- Production runs the pipeline every minute. Multi-week tests mirror that:
+  finish a week's games, `run_pipeline()`, move to the next week —
+  `update_weekly_winners` awards the latest *complete* week.
+- `assertStandings` is exhaustive per pool: every standings row must be
+  accounted for, so cross-tenant leakage fails even when the named users'
+  numbers are right.
+
+## Files
+
+| File | Covers |
+|---|---|
+| `factories.py` | Synthetic data with production-shaped rows (winner = team slug, pick ids = `pool-user-game`) |
+| `harness.py` | `GradingTestCase`: pipeline runner, stub stats provider, standings asserts |
+| `test_straight_up.py` | Clear winners, NFL ties, missed picks, idempotency, week-completion gate |
+| `test_tiebreakers.py` | Default chain: closest total score → closest combined yards; equidistant fall-through; co-winners; ESPN-outage deferral |
+| `test_spread_pool.py` | **Canary** pinning that `against_spread` pools still grade straight-up, plus skipped scaffolds for real spread scenarios |
+| `test_tenant_isolation.py` | Two families on the shared NFL slate: independent grading, standings, rules; pool-scoped recompute |
+| `test_rule_config.py` | `win_points`/`tie_points`, custom bonus, every tiebreaker variant, missed-pick policies |
+
+## The spread canary
+
+`pick_type=against_spread` has no grading backend yet (it's locked in every
+settings form). `SpreadPoolCanaryTest` asserts today's behavior — spread
+pools grade straight-up. When a spread backend lands, that test fails:
+delete the canary and un-skip `SpreadPoolTest`, whose scenarios (favorite
+covers, favorite doesn't cover, underdog outright, push) are already written
+with expected standings.
+
+## Adding a rule type
+
+New tiebreaker or scoring rule? Add the `PoolSettings` choice + strategy in
+`pickem_api/weekly_winners.py` (see its module docstring), then add a test
+here that sets the override in `create_league(...)` and asserts standings.
+Nothing in the harness needs to change.
+
+## Deliberately out of scope (future scenarios)
+
+- `update_season_winners` (season-champion flag) and `update_stats`
+  (accuracy / perfect weeks) — downstream of standings
+- Playoff weeks (`include_playoffs` is locked/unimplemented, same
+  treatment as spread when it lands)

--- a/pickem/grading_tests/factories.py
+++ b/pickem/grading_tests/factories.py
@@ -1,0 +1,206 @@
+"""Synthetic-data factories for the grading integration suite.
+
+Hand-rolled on purpose: ``requirements.txt`` is also the production image's
+dependency set, and these factories are thin enough that Factory Boy would
+add a dependency without removing meaningful code. The API mimics Factory
+Boy's shape — every field has a sensible default and each test overrides
+only what its scenario is about.
+
+The one rule that matters everywhere: factories write **production-shaped
+rows**. ``finish_game`` sets exactly the fields ``update_games`` would set
+from ESPN (scores, winner *slug*, ``statusType='finished'``) and nothing
+more — scoring/flagging is left to the real pipeline commands.
+"""
+
+import itertools
+from datetime import timedelta
+
+from django.contrib.auth.models import User
+from django.utils import timezone
+
+from pickem_api.models import (
+    Family,
+    FamilyMembership,
+    GamePicks,
+    GamesAndScores,
+    Pool,
+    PoolSettings,
+)
+
+#: Fixed synthetic season (YYZZ). Every factory and pipeline call pins this so
+#: ``get_season()`` (which hits the /api/currentseason endpoint) is never used.
+SEASON = 2526
+GAMEYEAR = "2025"
+
+_family_seq = itertools.count(1)
+_user_seq = itertools.count(1)
+_game_seq = itertools.count(1)
+
+#: Synthetic game ids start high above any real ESPN event id in fixtures.
+_GAME_ID_BASE = 900_000
+
+
+def create_family(name=None):
+    n = next(_family_seq)
+    name = name or f"Family {n}"
+    return Family.objects.create(name=name, slug=f"family-{n}")
+
+
+def create_user(username=None):
+    n = next(_user_seq)
+    username = username or f"user{n}"
+    return User.objects.create_user(
+        username=f"{username}-{n}",
+        email=f"{username}-{n}@example.test",
+        password="pw",
+        first_name=username.capitalize(),
+    )
+
+
+def join_family(family, user, role=FamilyMembership.Role.MEMBER):
+    return FamilyMembership.objects.create(family=family, user=user, role=role)
+
+
+def create_pool(family, season=SEASON, **settings_overrides):
+    """An active pool plus its PoolSettings row (overrides go to settings)."""
+    pool = Pool.objects.create(
+        family=family,
+        name=f"{family.name} Pool",
+        slug="main",
+        season=season,
+        competition="nfl",
+        status=Pool.Status.ACTIVE,
+        is_default=True,
+    )
+    PoolSettings.objects.create(pool=pool, **settings_overrides)
+    return pool
+
+
+class League:
+    """A family + active pool + users with active memberships.
+
+    ``league.users`` maps the requested username to its ``User``; games and
+    picks are created through module functions so tests read top-to-bottom.
+    """
+
+    def __init__(self, family, pool, users):
+        self.family = family
+        self.pool = pool
+        self.users = users
+
+    @property
+    def settings(self):
+        return self.pool.settings
+
+    def __getitem__(self, username):
+        return self.users[username]
+
+
+def create_league(*usernames, family_name=None, season=SEASON, **settings_overrides):
+    family = create_family(name=family_name)
+    pool = create_pool(family, season=season, **settings_overrides)
+    users = {}
+    for username in usernames:
+        user = create_user(username)
+        join_family(family, user)
+        users[username] = user
+    return League(family, pool, users)
+
+
+def create_game(
+    week,
+    *,
+    season=SEASON,
+    home=None,
+    away=None,
+    kickoff=None,
+    mnf=False,
+    tiebreaker_game=None,
+    home_win_probability=None,
+    away_win_probability=None,
+    spread=None,
+):
+    """A scheduled (not yet played) NFL game.
+
+    Kickoffs are placed in the past — ``week`` days after a base a month ago,
+    each game an hour after the previous — so picks are already locked and
+    ``update_missed_picks`` treats the game as started. ``mnf=True`` marks the
+    week's tiebreaker game and pushes it to the end of the week's slate.
+    """
+    n = next(_game_seq)
+    home = home or f"home{n}"
+    away = away or f"away{n}"
+    if kickoff is None:
+        base = timezone.now() - timedelta(days=30)
+        kickoff = base + timedelta(days=week, hours=n % 24)
+        if mnf:
+            kickoff += timedelta(days=1)
+    if tiebreaker_game is None:
+        tiebreaker_game = mnf
+    return GamesAndScores.objects.create(
+        id=_GAME_ID_BASE + n,
+        slug=f"{away}-{home}",
+        competition="nfl",
+        gameWeek=str(week),
+        gameyear=GAMEYEAR,
+        gameseason=season,
+        startTimestamp=kickoff,
+        statusType="scheduled",
+        statusTitle="Scheduled",
+        gameWinner="",
+        homeTeamId=n * 2,
+        homeTeamSlug=home,
+        homeTeamName=home.replace("-", " ").title(),
+        awayTeamId=n * 2 + 1,
+        awayTeamSlug=away,
+        awayTeamName=away.replace("-", " ").title(),
+        tieBreakerGame=tiebreaker_game,
+        homeTeamWinProbability=home_win_probability,
+        awayTeamWinProbability=away_win_probability,
+        spread=spread,
+    )
+
+
+def finish_game(game, home_score, away_score):
+    """Record a final score exactly the way ``update_games`` would.
+
+    Scores, the winner's **slug** (empty on a tie), and finished status —
+    nothing else. ``gameScored``/``pick_correct`` are the real pipeline's job.
+    """
+    game.homeTeamScore = home_score
+    game.awayTeamScore = away_score
+    if home_score > away_score:
+        game.gameWinner = game.homeTeamSlug
+    elif away_score > home_score:
+        game.gameWinner = game.awayTeamSlug
+    else:
+        game.gameWinner = ""
+    game.statusType = "finished"
+    game.statusTitle = "Final"
+    game.save()
+    return game
+
+
+def make_pick(pool, user, game, team, *, score=None, yards=None):
+    """A user's pick, id-keyed the same way the picks page builds it.
+
+    ``team`` is ``"home"``, ``"away"``, or a raw team slug. ``score``/``yards``
+    are the tiebreaker predictions (only meaningful on the tiebreaker game).
+    """
+    slug = {"home": game.homeTeamSlug, "away": game.awayTeamSlug}.get(team, team)
+    return GamePicks.objects.create(
+        id=f"{pool.id}-{user.id}-{game.id}",
+        pool=pool,
+        userEmail=user.email,
+        userID=str(user.id),
+        uid=user.id,
+        slug=game.slug,
+        competition=game.competition,
+        gameWeek=game.gameWeek,
+        gameyear=game.gameyear,
+        gameseason=game.gameseason,
+        pick_game_id=game.id,
+        pick=slug,
+        tieBreakerScore=score,
+        tieBreakerYards=yards,
+    )

--- a/pickem/grading_tests/harness.py
+++ b/pickem/grading_tests/harness.py
@@ -1,0 +1,136 @@
+"""Pipeline runner and assertions for the grading integration suite.
+
+Tests enter the grading engine through the same door production does: the
+management commands, in ``update_all`` order. The only substitution is the
+ESPN game-stats provider used by the combined-yards tiebreaker — the engine
+takes an injectable provider precisely so tests never touch the network.
+"""
+
+from io import StringIO
+from unittest import mock
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from pickem_api.models import userSeasonPoints
+
+from .factories import SEASON
+
+#: The grading slice of the production ``update_all`` pipeline. The two ESPN
+#: fetch steps (update_records, update_games) are replaced by synthetic data;
+#: update_season_winners/update_stats are downstream of standings and out of
+#: scope for this suite.
+PIPELINE = [
+    "update_missed_picks",
+    "update_picks",
+    "update_standings",
+    "update_weekly_winners",
+    "update_rankings",
+]
+
+
+class StubStatsProvider:
+    """GameStatsProvider stand-in for the combined-yards tiebreaker.
+
+    Configure a flat ``yards`` value or a ``per_game`` mapping of game id to
+    yards. Unconfigured lookups raise, which the engine treats exactly like
+    an ESPN outage (award deferred) — tests exercising that path get it for
+    free, and tests that hit it by accident fail visibly on standings.
+    """
+
+    def __init__(self, yards=None, per_game=None):
+        self.yards = yards
+        self.per_game = per_game or {}
+        self.calls = 0
+
+    def combined_yards(self, game_id):
+        self.calls += 1
+        if game_id in self.per_game:
+            return self.per_game[game_id]
+        if self.yards is None:
+            raise LookupError(f"StubStatsProvider has no yards for game {game_id}")
+        return self.yards
+
+
+class GradingTestCase(TestCase):
+    """Base class: run the real pipeline, assert exact standings."""
+
+    def run_pipeline(self, *, season=SEASON, yards=None, per_game_yards=None, week=None):
+        """Run the grading pipeline once, as the scheduler would.
+
+        Production runs ``update_all`` every minute; a week's winner is
+        awarded on the first run after its last game goes final. Multi-week
+        tests should therefore finish a week's games, call this, and repeat —
+        ``update_weekly_winners`` only awards the *latest* complete week.
+
+        Returns the combined command output (handy for asserting messages).
+        """
+        stub = StubStatsProvider(yards=yards, per_game=per_game_yards)
+        out = StringIO()
+        with mock.patch(
+            "pickem_api.management.commands.update_weekly_winners.EspnGameStatsProvider",
+            return_value=stub,
+        ):
+            for command in PIPELINE:
+                kwargs = {"season": season}
+                if command == "update_weekly_winners" and week is not None:
+                    kwargs["week"] = week
+                call_command(command, stdout=out, stderr=out, **kwargs)
+        self.last_stats_stub = stub
+        return out.getvalue()
+
+    # ------------------------------------------------------------------
+    # Assertions — always exact and exhaustive for the pool they target.
+    # ------------------------------------------------------------------
+
+    def standings_row(self, pool, user, *, season=SEASON):
+        return userSeasonPoints.objects.get(
+            pool=pool, gameseason=season, userID=str(user.id)
+        )
+
+    def assertStandings(self, pool, expected, *, season=SEASON):
+        """``expected``: iterable of (user, total_points, current_rank).
+
+        Exhaustive on purpose: every row in the pool's standings must be
+        accounted for, so a user leaking in from another pool fails the test
+        even when the expected users' numbers are all correct.
+        """
+        rows = userSeasonPoints.objects.filter(pool=pool, gameseason=season)
+        actual = {
+            row.userID: (row.total_points, row.current_rank) for row in rows
+        }
+        wanted = {
+            str(user.id): (total, rank) for user, total, rank in expected
+        }
+        names = {str(user.id): user.username for user, _, _ in expected}
+        readable_actual = {
+            names.get(uid, f"<unexpected userID {uid}>"): vals
+            for uid, vals in sorted(actual.items())
+        }
+        readable_wanted = {
+            names[uid]: vals for uid, vals in sorted(wanted.items())
+        }
+        self.assertEqual(
+            readable_actual,
+            readable_wanted,
+            f"Standings mismatch for {pool} (season {season}): "
+            "values are (total_points, current_rank)",
+        )
+
+    def assertWeek(self, pool, user, week, *, points=None, bonus=None,
+                   winner=None, season=SEASON):
+        """Check a user's per-week ledger; only the supplied fields."""
+        row = self.standings_row(pool, user, season=season)
+        label = f"{user.username} week {week} in {pool}"
+        if points is not None:
+            self.assertEqual(
+                getattr(row, f"week_{week}_points"), points, f"{label}: points"
+            )
+        if bonus is not None:
+            self.assertEqual(
+                getattr(row, f"week_{week}_bonus"), bonus, f"{label}: bonus"
+            )
+        if winner is not None:
+            self.assertEqual(
+                getattr(row, f"week_{week}_winner"), winner, f"{label}: winner flag"
+            )

--- a/pickem/grading_tests/test_rule_config.py
+++ b/pickem/grading_tests/test_rule_config.py
@@ -1,0 +1,190 @@
+"""Scenario 6 — per-family rule configuration.
+
+Every knob a commissioner can turn on ``PoolSettings`` that changes grading:
+point weights, the weekly-winner bonus, each tiebreaker chain variant, and
+the missed-pick policies. Adding a future rule = add a settings override in
+``create_league(...)`` and assert the standings it should produce.
+"""
+
+from pickem_api.models import GamePicks, PoolSettings, userSeasonPoints
+
+from .factories import create_game, create_league, finish_game, make_pick
+from .harness import GradingTestCase
+
+
+class ScoringWeightsTest(GradingTestCase):
+
+    def test_custom_win_and_tie_points(self):
+        league = create_league("alice", "bob", win_points=3, tie_points=1)
+        win_game = create_game(1)
+        tie_game = create_game(1)
+        mnf = create_game(1, mnf=True)
+
+        for game in (win_game, tie_game, mnf):
+            make_pick(league.pool, league["alice"], game, "home")
+            make_pick(league.pool, league["bob"], game, "away")
+        finish_game(win_game, 24, 10)   # home wins
+        finish_game(tie_game, 17, 17)   # NFL tie: both picks earn tie_points
+        finish_game(mnf, 14, 20)        # away wins
+
+        # yards supplied only because the incidental 4-4 tie walks the whole
+        # tiebreaker chain (which fetches actual yards even when nobody
+        # predicted any) before landing on co-winners.
+        self.run_pipeline(yards=700)
+
+        # alice: 1 win (3) + 1 tie (1) = 4; bob: 1 win (3) + 1 tie (1) = 4.
+        self.assertWeek(league.pool, league["alice"], 1, points=4)
+        self.assertWeek(league.pool, league["bob"], 1, points=4)
+
+    def test_custom_weekly_winner_bonus(self):
+        league = create_league("alice", "bob", weekly_winner_points=10)
+        game = create_game(1, mnf=True)
+        make_pick(league.pool, league["alice"], game, "home")
+        make_pick(league.pool, league["bob"], game, "away")
+        finish_game(game, 21, 7)
+
+        self.run_pipeline()
+
+        self.assertWeek(league.pool, league["alice"], 1, points=1, bonus=10, winner=True)
+        self.assertStandings(league.pool, [
+            (league["alice"], 11, 1),
+            (league["bob"], 0, 2),
+        ])
+
+
+class TiebreakerConfigurationTest(GradingTestCase):
+    """Non-default chains. Each test: alice and bob tie on pick totals."""
+
+    def _tied_week(self, league, *, alice_tb, bob_tb):
+        """One MNF game both users call correctly; tiebreaker guesses vary."""
+        mnf = create_game(1, mnf=True)
+        make_pick(
+            league.pool, league["alice"], mnf, "home",
+            score=alice_tb[0], yards=alice_tb[1],
+        )
+        make_pick(
+            league.pool, league["bob"], mnf, "home",
+            score=bob_tb[0], yards=bob_tb[1],
+        )
+        finish_game(mnf, 24, 21)  # total 45
+        return mnf
+
+    def test_total_score_without_going_over(self):
+        league = create_league(
+            "alice", "bob",
+            primary_tiebreaker=PoolSettings.PrimaryTiebreaker.TOTAL_SCORE_NO_OVER,
+        )
+        # Price-is-Right rules: bob is closer (46) but busted by going over;
+        # alice (38, under by 7) takes it.
+        self._tied_week(league, alice_tb=(38, None), bob_tb=(46, None))
+
+        self.run_pipeline()
+
+        self.assertWeek(league.pool, league["alice"], 1, bonus=2, winner=True)
+        self.assertWeek(league.pool, league["bob"], 1, winner=False)
+
+    def test_split_points_divides_the_bonus(self):
+        league = create_league(
+            "alice", "bob",
+            weekly_winner_points=5,
+            secondary_tiebreaker=PoolSettings.SecondaryTiebreaker.SPLIT_POINTS,
+        )
+        # Primary dead heat (40 vs 50 around 45) → split_points is terminal.
+        self._tied_week(league, alice_tb=(40, None), bob_tb=(50, None))
+
+        self.run_pipeline()
+
+        rows = userSeasonPoints.objects.filter(pool=league.pool)
+        self.assertTrue(all(row.week_1_winner for row in rows))
+        bonuses = sorted(row.week_1_bonus for row in rows)
+        # An odd bonus splits 3/2 — never lost, never duplicated.
+        self.assertEqual(bonuses, [2, 3])
+        self.assertEqual(
+            sorted(row.total_points for row in rows), [3, 4]
+        )
+
+    def test_coin_flip_produces_exactly_one_winner(self):
+        league = create_league(
+            "alice", "bob",
+            secondary_tiebreaker=PoolSettings.SecondaryTiebreaker.COIN_FLIP,
+        )
+        self._tied_week(league, alice_tb=(40, None), bob_tb=(50, None))
+
+        self.run_pipeline()
+        winners = list(
+            userSeasonPoints.objects.filter(pool=league.pool, week_1_winner=True)
+        )
+        self.assertEqual(len(winners), 1)
+        self.assertEqual(winners[0].week_1_bonus, 2)
+
+        # The flip is seeded from (pool, season, week): a forced re-award
+        # must land on the same person, so re-runs can never flip the result.
+        first_winner = winners[0].userID
+        from pickem_api.weekly_winners import award_weekly_winners
+
+        result = award_weekly_winners(
+            league.pool, league.pool.season, 1,
+            stats_provider=self.last_stats_stub, force=True,
+        )
+        self.assertEqual(result["winners"], [first_winner])
+
+    def test_allow_tiebreaker_off_means_co_winners(self):
+        league = create_league("alice", "bob", allow_tiebreaker=False)
+        # alice's near-perfect guess must be ignored: the pool turned
+        # tiebreakers off, so a points tie is simply shared.
+        self._tied_week(league, alice_tb=(45, None), bob_tb=(3, None))
+
+        self.run_pipeline()
+
+        self.assertWeek(league.pool, league["alice"], 1, bonus=2, winner=True)
+        self.assertWeek(league.pool, league["bob"], 1, bonus=2, winner=True)
+
+
+class MissedPickPolicyTest(GradingTestCase):
+
+    def test_auto_home_policy_generates_and_grades_a_home_pick(self):
+        league = create_league(
+            "alice", "bob",
+            missed_pick_policy=PoolSettings.MissedPickPolicy.AUTO_HOME,
+        )
+        game = create_game(1, mnf=True)
+        make_pick(league.pool, league["alice"], game, "away")
+        # bob never picks; the game has kicked off (factory kickoffs are in
+        # the past), so the policy fills in the home team for him.
+        finish_game(game, 28, 14)  # home wins → bob's auto pick is correct
+
+        self.run_pipeline()
+
+        auto = GamePicks.objects.get(
+            pool=league.pool, userID=str(league["bob"].id), pick_game_id=game.id
+        )
+        self.assertTrue(auto.auto_pick)
+        self.assertEqual(auto.pick, game.homeTeamSlug)
+        self.assertStandings(league.pool, [
+            (league["bob"], 3, 1),   # 1 + 2 bonus — the auto pick counts
+            (league["alice"], 0, 2),
+        ])
+
+    def test_auto_favorite_policy_follows_the_betting_favorite(self):
+        league = create_league(
+            "alice", "bob",
+            missed_pick_policy=PoolSettings.MissedPickPolicy.AUTO_FAVORITE,
+        )
+        game = create_game(
+            1, mnf=True,
+            home_win_probability=35.0, away_win_probability=65.0,
+        )
+        make_pick(league.pool, league["alice"], game, "home")
+        finish_game(game, 10, 30)  # the away favorite wins
+
+        self.run_pipeline()
+
+        auto = GamePicks.objects.get(
+            pool=league.pool, userID=str(league["bob"].id), pick_game_id=game.id
+        )
+        self.assertTrue(auto.auto_pick)
+        self.assertEqual(auto.pick, game.awayTeamSlug)
+        self.assertStandings(league.pool, [
+            (league["bob"], 3, 1),
+            (league["alice"], 0, 2),
+        ])

--- a/pickem/grading_tests/test_spread_pool.py
+++ b/pickem/grading_tests/test_spread_pool.py
@@ -1,0 +1,122 @@
+"""Scenario 4 — against-the-spread pools.
+
+There is no spread grading backend yet: ``pick_type=against_spread`` exists
+as a locked settings value (disabled in every form, rejected server-side)
+and ``update_picks`` grades every pool straight-up regardless.
+
+This file therefore has two jobs:
+
+1. A live **canary** that pins today's behavior: an against_spread pool is
+   still graded straight-up. The moment a spread backend changes grading,
+   the canary fails — that failure is the signal to delete the canary and
+   enable the scaffolded scenarios below.
+2. Skipped **scaffolds** for the four spread scenarios (favorite covers,
+   favorite wins without covering, underdog wins outright, push), written
+   against the documented spread convention (``GamesAndScores.spread`` is
+   positive when it favors the home team) with full expected standings.
+"""
+
+from unittest import skip
+
+from pickem_api.models import PoolSettings
+
+from .factories import create_game, create_league, finish_game, make_pick
+from .harness import GradingTestCase
+
+SPREAD_NOT_IMPLEMENTED = (
+    "against_spread grading is not implemented (locked in PoolSettings forms); "
+    "enable when the spread backend lands and the canary test fails"
+)
+
+
+def spread_league():
+    return create_league(
+        "alice", "bob",
+        pick_type=PoolSettings.PickType.AGAINST_SPREAD,
+    )
+
+
+class SpreadPoolCanaryTest(GradingTestCase):
+    """Fails the day spread grading lands — then flip the scaffolds on."""
+
+    def test_against_spread_pool_currently_grades_straight_up(self):
+        league = spread_league()
+        # Home favored by 7; home wins 20-17 → wins outright, does NOT cover.
+        game = create_game(1, spread=7.0, mnf=True)
+        make_pick(league.pool, league["alice"], game, "home")
+        make_pick(league.pool, league["bob"], game, "away")
+        finish_game(game, 20, 17)
+
+        self.run_pipeline()
+
+        # Straight-up grading: alice (outright winner) scores even though the
+        # favorite failed to cover. If this assertion starts failing, spread
+        # grading has landed: delete this test and un-skip the class below.
+        self.assertStandings(league.pool, [
+            (league["alice"], 3, 1),  # 1 win + 2 weekly-winner bonus
+            (league["bob"], 0, 2),
+        ])
+
+
+@skip(SPREAD_NOT_IMPLEMENTED)
+class SpreadPoolTest(GradingTestCase):
+    """Expected against-the-spread behavior, ready to enable."""
+
+    def test_favorite_covers(self):
+        league = spread_league()
+        game = create_game(1, spread=7.0, mnf=True)  # home favored by 7
+        make_pick(league.pool, league["alice"], game, "home")
+        make_pick(league.pool, league["bob"], game, "away")
+        finish_game(game, 27, 10)  # home wins by 17: covers
+
+        self.run_pipeline()
+
+        self.assertStandings(league.pool, [
+            (league["alice"], 3, 1),
+            (league["bob"], 0, 2),
+        ])
+
+    def test_favorite_wins_but_does_not_cover(self):
+        league = spread_league()
+        game = create_game(1, spread=7.0, mnf=True)
+        make_pick(league.pool, league["alice"], game, "home")
+        make_pick(league.pool, league["bob"], game, "away")
+        finish_game(game, 20, 17)  # home wins by 3: fails to cover
+
+        self.run_pipeline()
+
+        # Against the spread the underdog side is the winning ticket.
+        self.assertStandings(league.pool, [
+            (league["bob"], 3, 1),
+            (league["alice"], 0, 2),
+        ])
+
+    def test_underdog_wins_outright(self):
+        league = spread_league()
+        game = create_game(1, spread=7.0, mnf=True)
+        make_pick(league.pool, league["alice"], game, "home")
+        make_pick(league.pool, league["bob"], game, "away")
+        finish_game(game, 13, 24)  # underdog wins outright
+
+        self.run_pipeline()
+
+        self.assertStandings(league.pool, [
+            (league["bob"], 3, 1),
+            (league["alice"], 0, 2),
+        ])
+
+    def test_push_awards_tie_points_to_both_sides(self):
+        league = spread_league()
+        league.settings.tie_points = 1
+        league.settings.save()
+        game = create_game(1, spread=7.0, mnf=True)
+        make_pick(league.pool, league["alice"], game, "home")
+        make_pick(league.pool, league["bob"], game, "away")
+        finish_game(game, 24, 17)  # home wins by exactly 7: push
+
+        self.run_pipeline()
+
+        # A push is a spread-world tie: both sides get the pool's tie_points
+        # and there is no weekly winner (nobody "scored" a win).
+        self.assertWeek(league.pool, league["alice"], 1, points=1, winner=False)
+        self.assertWeek(league.pool, league["bob"], 1, points=1, winner=False)

--- a/pickem/grading_tests/test_straight_up.py
+++ b/pickem/grading_tests/test_straight_up.py
@@ -1,0 +1,185 @@
+"""Scenario 1 — straight-up pools.
+
+Clear winners, multiple users, exact point totals and rankings, plus the
+straight-up edge cases the pipeline must survive: a real NFL tie, a missed
+pick under the default policy, and re-running the pipeline (the scheduler
+runs it every minute in production, so idempotency is a hard requirement).
+"""
+
+from pickem_api.models import GamePicks, GamesAndScores
+
+from .factories import create_game, create_league, finish_game, make_pick
+from .harness import GradingTestCase
+
+
+class StraightUpPoolTest(GradingTestCase):
+
+    def test_clear_winner_single_week(self):
+        league = create_league("alice", "bob", "carol")
+        g1 = create_game(1)
+        g2 = create_game(1)
+        g3 = create_game(1)
+        mnf = create_game(1, mnf=True)
+
+        # alice 4 correct, bob 2, carol 1 (picks made before results exist).
+        for game, alice_side, bob_side, carol_side in [
+            (g1, "home", "home", "away"),
+            (g2, "away", "home", "home"),
+            (g3, "home", "away", "home"),
+            (mnf, "home", "home", "away"),
+        ]:
+            make_pick(league.pool, league["alice"], game, alice_side)
+            make_pick(league.pool, league["bob"], game, bob_side)
+            make_pick(league.pool, league["carol"], game, carol_side)
+
+        finish_game(g1, 27, 10)   # home wins
+        finish_game(g2, 14, 31)   # away wins
+        finish_game(g3, 21, 17)   # home wins
+        finish_game(mnf, 24, 21)  # home wins
+
+        self.run_pipeline()
+
+        self.assertWeek(league.pool, league["alice"], 1, points=4, bonus=2, winner=True)
+        self.assertWeek(league.pool, league["bob"], 1, points=2, winner=False)
+        self.assertWeek(league.pool, league["carol"], 1, points=1, winner=False)
+        self.assertStandings(league.pool, [
+            (league["alice"], 6, 1),   # 4 wins + 2 weekly-winner bonus
+            (league["bob"], 2, 2),
+            (league["carol"], 1, 3),
+        ])
+
+    def test_two_week_season_accumulates_totals_and_ranks(self):
+        league = create_league("alice", "bob", "carol")
+
+        # Week 1: alice dominates (see test above for the shape).
+        w1 = [create_game(1), create_game(1), create_game(1, mnf=True)]
+        sides_w1 = {
+            "alice": ["home", "home", "home"],   # 3 correct
+            "bob": ["home", "away", "away"],     # 1 correct
+            "carol": ["away", "home", "away"],   # 1 correct
+        }
+        for username, sides in sides_w1.items():
+            for game, side in zip(w1, sides):
+                make_pick(league.pool, league[username], game, side)
+        for game in w1:
+            finish_game(game, 24, 17)  # home wins all three
+        self.run_pipeline()
+
+        # Week 2: bob dominates. The scheduler runs between weeks, so the
+        # pipeline runs once per completed week — same as production.
+        w2 = [create_game(2), create_game(2), create_game(2, mnf=True)]
+        sides_w2 = {
+            "alice": ["away", "away", "home"],   # 1 correct
+            "bob": ["home", "home", "home"],     # 3 correct
+            "carol": ["home", "away", "away"],   # 1 correct
+        }
+        for username, sides in sides_w2.items():
+            for game, side in zip(w2, sides):
+                make_pick(league.pool, league[username], game, side)
+        for game in w2:
+            finish_game(game, 30, 20)  # home wins all three
+        self.run_pipeline()
+
+        self.assertWeek(league.pool, league["alice"], 1, points=3, bonus=2, winner=True)
+        self.assertWeek(league.pool, league["bob"], 2, points=3, bonus=2, winner=True)
+        # alice: (3+2) + 1 = 6; bob: 1 + (3+2) = 6 — tied for first.
+        self.assertStandings(league.pool, [
+            (league["alice"], 6, 1),
+            (league["bob"], 6, 1),
+            (league["carol"], 2, 3),
+        ])
+
+    def test_real_nfl_tie_completes_week_and_scores_no_pick(self):
+        league = create_league("alice", "bob")
+        tie_game = create_game(1)
+        g2 = create_game(1)
+        mnf = create_game(1, mnf=True)
+
+        for game in (tie_game, g2, mnf):
+            make_pick(league.pool, league["alice"], game, "home")
+            make_pick(league.pool, league["bob"], game, "away")
+
+        finish_game(tie_game, 20, 20)  # ends in a real NFL tie
+        finish_game(g2, 24, 17)
+        finish_game(mnf, 31, 28)
+
+        self.run_pipeline()
+
+        # Nobody's tie-game pick is correct (default tie_points=0), but the
+        # tie must not wedge the week: it gets marked scored and the weekly
+        # winner is still awarded on the remaining games.
+        tie_game.refresh_from_db()
+        self.assertTrue(tie_game.gameScored)
+        self.assertFalse(
+            GamePicks.objects.filter(pick_game_id=tie_game.id, pick_correct=True).exists()
+        )
+        self.assertWeek(league.pool, league["alice"], 1, points=2, bonus=2, winner=True)
+        self.assertStandings(league.pool, [
+            (league["alice"], 4, 1),
+            (league["bob"], 0, 2),
+        ])
+
+    def test_missed_pick_scores_zero_under_default_policy(self):
+        league = create_league("alice", "bob")
+        g1 = create_game(1)
+        mnf = create_game(1, mnf=True)
+
+        make_pick(league.pool, league["alice"], g1, "home")
+        make_pick(league.pool, league["alice"], mnf, "home")
+        make_pick(league.pool, league["bob"], mnf, "home")  # bob skipped g1
+
+        finish_game(g1, 28, 7)
+        finish_game(mnf, 24, 21)
+
+        self.run_pipeline()
+
+        # zero_points is the default policy: no auto pick is generated.
+        self.assertFalse(GamePicks.objects.filter(auto_pick=True).exists())
+        self.assertStandings(league.pool, [
+            (league["alice"], 4, 1),  # 2 wins + 2 bonus
+            (league["bob"], 1, 2),
+        ])
+
+    def test_pipeline_rerun_is_idempotent(self):
+        league = create_league("alice", "bob")
+        g1 = create_game(1)
+        mnf = create_game(1, mnf=True)
+        for game in (g1, mnf):
+            make_pick(league.pool, league["alice"], game, "home")
+            make_pick(league.pool, league["bob"], game, "away")
+        finish_game(g1, 21, 14)
+        finish_game(mnf, 27, 24)
+
+        self.run_pipeline()
+        self.run_pipeline()  # scheduler fires again a minute later
+
+        expected = [
+            (league["alice"], 4, 1),  # bonus applied exactly once
+            (league["bob"], 0, 2),
+        ]
+        self.assertStandings(league.pool, expected)
+        self.assertWeek(league.pool, league["alice"], 1, points=2, bonus=2, winner=True)
+
+
+class WeekCompletionGateTest(GradingTestCase):
+    """The weekly bonus must never be awarded while games are still live."""
+
+    def test_no_award_until_last_game_of_week_finishes(self):
+        league = create_league("alice", "bob")
+        g1 = create_game(1)
+        mnf = create_game(1, mnf=True)
+        for game in (g1, mnf):
+            make_pick(league.pool, league["alice"], game, "home")
+            make_pick(league.pool, league["bob"], game, "away")
+
+        finish_game(g1, 21, 14)  # MNF still to be played
+
+        self.run_pipeline()
+        self.assertWeek(league.pool, league["alice"], 1, points=1, winner=False)
+        self.assertFalse(
+            GamesAndScores.objects.get(pk=mnf.pk).gameScored
+        )
+
+        finish_game(mnf, 27, 24)
+        self.run_pipeline()
+        self.assertWeek(league.pool, league["alice"], 1, points=2, bonus=2, winner=True)

--- a/pickem/grading_tests/test_tenant_isolation.py
+++ b/pickem/grading_tests/test_tenant_isolation.py
@@ -1,0 +1,148 @@
+"""Scenario 5 — tenant (family) isolation.
+
+One schema fact shapes these tests: NFL games are global per season —
+families share the slate (there is no per-family game table). Isolation
+lives one level down, in ``GamePicks.pool``, ``userSeasonPoints.pool`` and
+per-pool ``PoolSettings``. So the assertions here are:
+
+* one pipeline run grades every family, but each family's results are
+  computed only from its own picks and rules;
+* standings are exhaustive per pool — a user from another family showing
+  up in a pool's standings fails the test;
+* the same person in two families is two independent competitors;
+* pool-scoped recompute (``update_standings --pool``) touches nothing else.
+"""
+
+from django.core.management import call_command
+from io import StringIO
+
+from pickem_api.models import userSeasonPoints
+
+from .factories import create_game, create_league, create_user, finish_game, join_family, make_pick
+from .harness import GradingTestCase
+
+
+def _shared_slate():
+    """The league-independent NFL week both families play against."""
+    return [create_game(1), create_game(1), create_game(1, mnf=True)]
+
+
+class TenantIsolationTest(GradingTestCase):
+
+    def test_one_pipeline_run_grades_each_family_independently(self):
+        games = _shared_slate()
+        smith = create_league("alice", "bob", family_name="Smith")
+        jones = create_league("cara", "dan", family_name="Jones")
+
+        # Same slate, opposite convictions.
+        picks = {
+            (smith, "alice"): ["home", "home", "home"],  # 3 correct
+            (smith, "bob"): ["away", "home", "away"],    # 1 correct
+            (jones, "cara"): ["away", "away", "home"],   # 1 correct
+            (jones, "dan"): ["home", "away", "home"],    # 2 correct
+        }
+        for (league, username), sides in picks.items():
+            for game, side in zip(games, sides):
+                make_pick(league.pool, league[username], game, side)
+        for game in games:
+            finish_game(game, 24, 17)  # home sweeps
+
+        self.run_pipeline()  # a single run — production grades all tenants
+
+        # Exhaustive per pool: correct numbers AND nobody leaked across.
+        self.assertStandings(smith.pool, [
+            (smith["alice"], 5, 1),  # 3 + 2 bonus
+            (smith["bob"], 1, 2),
+        ])
+        self.assertStandings(jones.pool, [
+            (jones["dan"], 4, 1),    # 2 + 2 bonus
+            (jones["cara"], 1, 2),
+        ])
+
+    def test_same_person_in_two_families_is_two_independent_competitors(self):
+        games = _shared_slate()
+        smith = create_league("alice", family_name="Smith")
+        jones = create_league("cara", family_name="Jones")
+        sam = create_user("sam")
+        join_family(smith.family, sam)
+        join_family(jones.family, sam)
+
+        # sam sweeps in Smith, goes 0-for-3 in Jones.
+        for game in games:
+            make_pick(smith.pool, sam, game, "home")
+            make_pick(jones.pool, sam, game, "away")
+            make_pick(smith.pool, smith["alice"], game, "away")
+            make_pick(jones.pool, jones["cara"], game, "home")
+        for game in games:
+            finish_game(game, 21, 14)
+
+        self.run_pipeline()
+
+        self.assertStandings(smith.pool, [
+            (sam, 5, 1),             # 3 + 2 bonus
+            (smith["alice"], 0, 2),
+        ])
+        self.assertStandings(jones.pool, [
+            (jones["cara"], 5, 1),
+            (sam, 0, 2),
+        ])
+
+    def test_rule_configuration_is_isolated_per_family(self):
+        games = _shared_slate()
+        smith = create_league("alice", "bob", family_name="Smith")  # defaults
+        jones = create_league(
+            "cara", "dan", family_name="Jones",
+            win_points=3, weekly_winner_points=10,
+        )
+
+        # Identical pick patterns in both pools.
+        for league, top, other in ((smith, "alice", "bob"), (jones, "cara", "dan")):
+            for game in games:
+                make_pick(league.pool, league[top], game, "home")
+                make_pick(league.pool, league[other], game, "away")
+        for game in games:
+            finish_game(game, 28, 3)
+
+        self.run_pipeline()
+
+        # Same performance, different rules, different numbers — and neither
+        # pool's configuration bled into the other.
+        self.assertStandings(smith.pool, [
+            (smith["alice"], 5, 1),   # 3×1 + 2
+            (smith["bob"], 0, 2),
+        ])
+        self.assertStandings(jones.pool, [
+            (jones["cara"], 19, 1),   # 3×3 + 10
+            (jones["dan"], 0, 2),
+        ])
+
+    def test_pool_scoped_recompute_leaves_other_pools_untouched(self):
+        games = _shared_slate()
+        smith = create_league("alice", family_name="Smith")
+        jones = create_league("cara", family_name="Jones")
+        for game in games:
+            make_pick(smith.pool, smith["alice"], game, "home")
+            make_pick(jones.pool, jones["cara"], game, "home")
+        for game in games:
+            finish_game(game, 17, 10)
+
+        # Grade picks globally (as production does), then recompute standings
+        # for the Smith pool only.
+        out = StringIO()
+        call_command("update_picks", season=smith.pool.season, stdout=out)
+        call_command(
+            "update_standings",
+            season=smith.pool.season, pool=smith.pool.id, stdout=out,
+        )
+
+        self.assertEqual(
+            self.standings_row(smith.pool, smith["alice"]).total_points, 3
+        )
+        self.assertFalse(
+            userSeasonPoints.objects.filter(pool=jones.pool).exists(),
+            "pool-scoped recompute must not create rows for other pools",
+        )
+
+        # The regular full pipeline then brings Jones up to date too.
+        self.run_pipeline()
+        self.assertStandings(jones.pool, [(jones["cara"], 5, 1)])

--- a/pickem/grading_tests/test_tiebreakers.py
+++ b/pickem/grading_tests/test_tiebreakers.py
@@ -1,0 +1,119 @@
+"""Scenarios 2–3 — the default tiebreaker chain.
+
+Default pool rules: primary = closest predicted total score of the
+tiebreaker (MNF) game, secondary = closest predicted combined offensive
+yards. Distance is absolute, so equidistant predictions (40 and 50 around
+an actual 45) tie the primary and fall through to the secondary.
+
+Combined yards come from ESPN in production; here the injected stub plays
+ESPN, so the real engine code runs end-to-end without network.
+"""
+
+from .factories import create_game, create_league, finish_game, make_pick
+from .harness import GradingTestCase
+
+
+class TiebreakerChainTest(GradingTestCase):
+
+    def setUp(self):
+        """alice and bob finish the week on identical pick totals (2 each),
+        so the weekly winner always comes down to the tiebreaker chain."""
+        self.league = create_league("alice", "bob")
+        self.pool = self.league.pool
+        self.opener = create_game(1)
+        self.mnf = create_game(1, mnf=True)
+
+    def _run_week(self, *, alice, bob, yards=None):
+        """Both users pick both winners; tiebreaker predictions differ."""
+        for user, (score, predicted_yards) in (
+            (self.league["alice"], alice),
+            (self.league["bob"], bob),
+        ):
+            make_pick(self.pool, user, self.opener, "home")
+            make_pick(
+                self.pool, user, self.mnf, "home",
+                score=score, yards=predicted_yards,
+            )
+        finish_game(self.opener, 20, 13)
+        finish_game(self.mnf, 24, 21)  # actual combined score: 45
+        return self.run_pipeline(yards=yards)
+
+    def test_first_tiebreaker_closest_total_score_wins(self):
+        self._run_week(
+            alice=(44, None),  # off by 1
+            bob=(48, None),    # off by 3
+        )
+
+        self.assertWeek(self.pool, self.league["alice"], 1, bonus=2, winner=True)
+        self.assertWeek(self.pool, self.league["bob"], 1, winner=False)
+        self.assertStandings(self.pool, [
+            (self.league["alice"], 4, 1),
+            (self.league["bob"], 2, 2),
+        ])
+
+    def test_equidistant_predictions_fall_through_to_combined_yards(self):
+        # The spec's exact case: actual total 45, predictions 40 and 50 are
+        # equally close — the primary tiebreaker is itself a tie, and the
+        # secondary (combined yards) must decide.
+        self._run_week(
+            alice=(40, 690),   # score off 5; yards off 10 of actual 700
+            bob=(50, 800),     # score off 5; yards off 100
+            yards=700,
+        )
+
+        # The engine really consulted the (stubbed) stats provider.
+        self.assertGreaterEqual(self.last_stats_stub.calls, 1)
+        self.assertWeek(self.pool, self.league["alice"], 1, bonus=2, winner=True)
+        self.assertWeek(self.pool, self.league["bob"], 1, winner=False)
+        self.assertStandings(self.pool, [
+            (self.league["alice"], 4, 1),
+            (self.league["bob"], 2, 2),
+        ])
+
+    def test_second_tiebreaker_selects_correct_winner_outright(self):
+        # Primary dead heat again, but this time bob's yards are closer.
+        self._run_week(
+            alice=(40, 500),   # yards off 200
+            bob=(50, 720),     # yards off 20
+            yards=700,
+        )
+
+        self.assertWeek(self.pool, self.league["bob"], 1, bonus=2, winner=True)
+        self.assertStandings(self.pool, [
+            (self.league["bob"], 4, 1),
+            (self.league["alice"], 2, 2),
+        ])
+
+    def test_chain_exhausted_means_co_winners_with_full_bonus(self):
+        # Equidistant scores AND equidistant yards: nothing can separate
+        # them, so both are weekly winners and each gets the full bonus.
+        self._run_week(
+            alice=(40, 690),
+            bob=(50, 710),
+            yards=700,
+        )
+
+        self.assertWeek(self.pool, self.league["alice"], 1, bonus=2, winner=True)
+        self.assertWeek(self.pool, self.league["bob"], 1, bonus=2, winner=True)
+        self.assertStandings(self.pool, [
+            (self.league["alice"], 4, 1),
+            (self.league["bob"], 4, 1),
+        ])
+
+    def test_missing_yards_data_defers_award_instead_of_guessing(self):
+        # ESPN outage: the provider errors. Points must still land, but the
+        # bonus is deferred (not guessed, not co-awarded) until data exists.
+        with self.assertLogs("pickem_api.weekly_winners", level="ERROR"):
+            self._run_week(
+                alice=(40, 690),
+                bob=(50, 800),
+                yards=None,  # stub raises, exactly like an ESPN failure
+            )
+
+        self.assertWeek(self.pool, self.league["alice"], 1, points=2, winner=False)
+        self.assertWeek(self.pool, self.league["bob"], 1, points=2, winner=False)
+
+        # The next scheduler run finds ESPN healthy and awards normally.
+        self.run_pipeline(yards=700)
+        self.assertWeek(self.pool, self.league["alice"], 1, bonus=2, winner=True)
+        self.assertWeek(self.pool, self.league["bob"], 1, winner=False)

--- a/pickem/pickem/test_settings_postgres.py
+++ b/pickem/pickem/test_settings_postgres.py
@@ -1,0 +1,26 @@
+"""Test settings backed by PostgreSQL — the production database engine.
+
+Used by the grading integration workflow so the suite runs against real
+Postgres behavior (transactions, constraint timing, DISTINCT semantics)
+instead of SQLite. Everything else is inherited from test_settings.
+
+Connection comes from the same DATABASE_* variables production uses,
+defaulting to a local service on 5432 (the GitHub Actions service
+container). The test runner creates/migrates its own `test_<NAME>`
+database, so the configured user needs CREATEDB.
+"""
+
+import os
+
+from pickem.test_settings import *  # noqa: F401, F403
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': os.environ.get('DATABASE_NAME', 'pickem_test'),
+        'USER': os.environ.get('DATABASE_USER', 'postgres'),
+        'PASSWORD': os.environ.get('DATABASE_PASS', 'postgres'),
+        'HOST': os.environ.get('DATABASE_HOST', 'localhost'),
+        'PORT': os.environ.get('DATABASE_PORT', '5432'),
+    }
+}


### PR DESCRIPTION
## Summary

Adds `pickem/grading_tests/` — an end-to-end integration suite that exercises the **real production grading pipeline** against synthetic data, plus a dedicated GitHub Actions workflow that runs it on PostgreSQL 16.

Every test creates synthetic families, pools, users, games, and picks; records final scores the way `update_games` would; runs the actual management commands (`update_missed_picks → update_picks → update_standings → update_weekly_winners → update_rankings`, in `update_all` order); and asserts exact standings. No grading logic is duplicated in assertions. The only substitution is the ESPN yards provider, replaced through the tiebreaker engine's existing injection point.

## Coverage

- **Straight-up pools** — clear winners, multi-week totals and ranks, real NFL ties, missed picks under `zero_points`, pipeline idempotency, and the week-completion gate (no bonus while MNF is live)
- **Default tiebreaker chain** — closest total score; the equidistant case (40 and 50 around an actual 45) falling through to closest combined yards; co-winners when the chain exhausts; ESPN-outage deferral (bonus deferred, not guessed)
- **Spread pools** — a live **canary** pinning that `against_spread` pools currently grade straight-up (it fails the day a spread backend lands), plus `@skip` scaffolds for favorite-covers / wins-without-covering / underdog-outright / push, with expected standings already written
- **Tenant isolation** — families share the NFL slate by schema design, so the tests assert what the schema guarantees: disjoint picks/standings/rules per pool (exhaustive `assertStandings` fails on any cross-pool leakage), the same person competing independently in two families, and `update_standings --pool` touching nothing else
- **Rule configuration** — `win_points`/`tie_points`, custom weekly bonus, `total_score_no_over`, `split_points` (odd bonus splits 3/2), deterministic `coin_flip`, `allow_tiebreaker` off, and both auto missed-pick policies

## CI

- New `grading-integration-tests.yaml`: `postgres:16` service, explicit `migrate` step (validates the full migration chain on the production engine — the SQLite job never did), then the suite via new `pickem.test_settings_postgres`
- The existing SQLite PR job discovers the package automatically

## Verification

- 28 grading tests (24 active, 4 skipped scaffolds) pass on SQLite and on a real PostgreSQL instance
- Full repo suite: 551 tests pass

Design decisions (Django `TestCase` over pytest, hand-rolled factories over Factory Boy) are documented in `docs/superpowers/specs/2026-07-16-grading-integration-tests-design.md` and `pickem/grading_tests/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive end-to-end grading coverage for scoring, tiebreakers, missed picks, weekly completion, reruns, and tenant isolation.
  * Added PostgreSQL-backed test execution to validate grading and database migrations in a production-like environment.
  * Added documentation for running and understanding the grading integration tests.

* **Bug Fixes**
  * Automated checks now detect grading regressions on pull requests and updates to the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->