### PR TITLE
fix(invite): link 500s, http→https links, rebranded invite email

### DIFF
--- a/pickem/pickem/settings.py
+++ b/pickem/pickem/settings.py
@@ -296,6 +296,12 @@ if not DEBUG:
     SECURE_HSTS_PRELOAD = True
     # SECURE_SSL_REDIRECT is intentionally left off: the app runs on plain HTTP
     # behind the Cloudflare TLS edge, so an in-app redirect would loop.
+    # Trust the edge/ingress X-Forwarded-Proto so request.is_secure() (and thus
+    # request.build_absolute_uri) knows the original request was HTTPS — without
+    # it, generated absolute URLs (e.g. invite links in emails) come out as
+    # http://. Safe here because all traffic reaches the app through Cloudflare
+    # + the nginx ingress, which set this header.
+    SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 AWS_S3_ADDRESSING_STYLE = "virtual"
 

--- a/pickem/pickem_homepage/templates/emails/family_invite.html
+++ b/pickem/pickem_homepage/templates/emails/family_invite.html
@@ -5,48 +5,48 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>You're invited to {{ family_name }}</title>
 </head>
-<body style="margin:0; padding:0; background:#eef1f5; font-family:'Segoe UI',Helvetica,Arial,sans-serif; color:#1f2937;">
+<body style="margin:0; padding:0; background:#f0f2f5; font-family:'Inter','Segoe UI',Helvetica,Arial,sans-serif; color:#1d1e1f;">
   <!-- Email clients need table layout + inline styles; keep this self-contained. -->
-  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#eef1f5; padding:24px 0;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#f0f2f5; padding:24px 0;">
     <tr>
       <td align="center">
-        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:560px; background:#ffffff; border-radius:14px; overflow:hidden; box-shadow:0 1px 3px rgba(16,24,40,0.08);">
-          <!-- Header -->
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:560px; background:#ffffff; border-radius:16px; overflow:hidden; border:1px solid #dcdcdd;">
+          <!-- Header: matches the site's dark nav; navy is the brand accent. -->
           <tr>
-            <td style="background:#0B3D91; padding:28px 32px; text-align:center;">
-              {% if logo_url %}<img src="{{ logo_url }}" alt="Family Pick'em" height="40" style="height:40px; width:auto; display:inline-block;">{% else %}<span style="color:#ffffff; font-size:22px; font-weight:800;">Family Pick'em</span>{% endif %}
+            <td style="background:#0f172a; padding:26px 32px; text-align:center; border-bottom:3px solid #0B3D91;">
+              {% if logo_url %}<img src="{{ logo_url }}" alt="Family Pick'em" height="38" style="height:38px; width:auto; display:inline-block;">{% else %}<span style="color:#ffffff; font-size:22px; font-weight:800; letter-spacing:-0.01em;">🏈 Family Pick&rsquo;em</span>{% endif %}
             </td>
           </tr>
           <!-- Body -->
           <tr>
-            <td style="padding:36px 32px 8px;">
-              <p style="margin:0 0 6px; font-size:13px; text-transform:uppercase; letter-spacing:0.08em; color:#0B3D91; font-weight:700;">🏈 You're invited</p>
-              <h1 style="margin:0 0 16px; font-size:24px; line-height:1.25; color:#111827;">Join {{ family_name }} on Family&nbsp;Pick'em</h1>
-              <p style="margin:0 0 24px; font-size:16px; line-height:1.6; color:#4b5563;">
-                You've been invited to play in <strong>{{ pool_name }}</strong>. Pick game winners each week, climb the leaderboard, and settle who really knows football.
+            <td style="padding:34px 32px 8px;">
+              <p style="margin:0 0 8px; font-size:12px; text-transform:uppercase; letter-spacing:0.09em; color:#3CA455; font-weight:700;">You're in</p>
+              <h1 style="margin:0 0 16px; font-size:23px; line-height:1.3; color:#1d1e1f; font-weight:800;">Come join {{ family_name }}</h1>
+              <p style="margin:0 0 26px; font-size:16px; line-height:1.6; color:#4b5563;">
+                Someone saved you a spot in their <strong>{{ pool_name }}</strong> league. Call each week&rsquo;s games, keep an eye on the standings, and find out who actually knows their football. Takes about two minutes to get in.
               </p>
               <!-- Bulletproof CTA button -->
-              <table role="presentation" cellpadding="0" cellspacing="0" style="margin:0 0 24px;">
+              <table role="presentation" cellpadding="0" cellspacing="0" style="margin:0 0 26px;">
                 <tr>
                   <td align="center" bgcolor="#0B3D91" style="border-radius:10px;">
-                    <a href="{{ invite_link }}" style="display:inline-block; padding:14px 28px; font-size:16px; font-weight:600; color:#ffffff; text-decoration:none; border-radius:10px;">Accept your invite</a>
+                    <a href="{{ invite_link }}" style="display:inline-block; padding:14px 30px; font-size:16px; font-weight:700; color:#ffffff; text-decoration:none; border-radius:10px;">Join the league</a>
                   </td>
                 </tr>
               </table>
-              <p style="margin:0 0 6px; font-size:13px; color:#6b7280;">If the button doesn't work, copy and paste this link:</p>
+              <p style="margin:0 0 6px; font-size:13px; color:#6c6d6f;">Button not working? Paste this link into your browser:</p>
               <p style="margin:0 0 8px; font-size:13px; word-break:break-all;"><a href="{{ invite_link }}" style="color:#0B3D91;">{{ invite_link }}</a></p>
             </td>
           </tr>
           <!-- Footer -->
           <tr>
-            <td style="padding:20px 32px 28px; border-top:1px solid #eef1f5;">
-              <p style="margin:0; font-size:12px; line-height:1.5; color:#98a2b3;">
-                You received this because someone invited you to a Family Pick'em league. If you weren't expecting it, you can safely ignore this email.
+            <td style="padding:20px 32px 28px; border-top:1px solid #f0f2f5;">
+              <p style="margin:0; font-size:12px; line-height:1.5; color:#9ca3af;">
+                Not sure why you got this? Someone probably typo&rsquo;d an email address &mdash; you can ignore it and nothing happens.
               </p>
             </td>
           </tr>
         </table>
-        <p style="max-width:560px; margin:16px auto 0; font-size:12px; color:#98a2b3; text-align:center;">Family Pick'em &middot; Your NFL pick'em league</p>
+        <p style="max-width:560px; margin:16px auto 0; font-size:12px; color:#9ca3af; text-align:center;">Family Pick&rsquo;em &middot; NFL pick&rsquo;em with your people</p>
       </td>
     </tr>
   </table>

--- a/pickem/pickem_homepage/templates/emails/family_invite.txt
+++ b/pickem/pickem_homepage/templates/emails/family_invite.txt
@@ -1,12 +1,14 @@
-{% autoescape off %}You're invited to join {{ family_name }} on Family Pick'em!
+{% autoescape off %}Come join {{ family_name }} on Family Pick'em!
 
-You've been invited to play in {{ pool_name }}. Pick game winners each week,
-climb the leaderboard, and settle who really knows football.
+Someone saved you a spot in their {{ pool_name }} league. Call each week's games,
+keep an eye on the standings, and find out who actually knows their football.
+Takes about two minutes to get in.
 
-Accept your invite:
+Join the league:
 {{ invite_link }}
 
-If you weren't expecting this, you can safely ignore this email.
+Not sure why you got this? Someone probably typo'd an email address — you can
+ignore it and nothing happens.
 
 — Family Pick'em
 {% endautoescape %}

--- a/pickem/pickem_homepage/templates/pickem/join_family.html
+++ b/pickem/pickem_homepage/templates/pickem/join_family.html
@@ -22,6 +22,9 @@
                     Invitation link
                 </label>
                 {{ form.code }}
+                {% if invite_error %}
+                    <div class="mt-2 text-sm text-red-600 dark:text-red-400"><p>{{ invite_error }}</p></div>
+                {% endif %}
                 {% if form.code.errors %}
                     <div class="mt-2 text-sm text-red-600 dark:text-red-400">
                         {% for error in form.code.errors %}

--- a/pickem/pickem_homepage/tests.py
+++ b/pickem/pickem_homepage/tests.py
@@ -6218,6 +6218,37 @@ class InviteFlowTests(TestCase):
         )
         self.assertEqual(invite.use_count, 0)
 
+    def test_link_click_wrong_account_shows_error_not_500(self):
+        # GET the email link while signed in as the wrong account: must render the
+        # graceful error page (200), not 500 on an unbound-form add_error().
+        self._invitation(raw_code="wrong-link", recipient_email="someoneelse@example.com")
+        self.client.force_login(self.joiner)
+
+        response = self.client.get(self._link_url("wrong-link"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "someoneelse@example.com")
+        self.assertFalse(
+            FamilyMembership.objects.filter(family=self.family, user=self.joiner).exists()
+        )
+
+    def test_link_click_reaccept_after_joining_redirects_home(self):
+        # Clicking a spent link after you've already joined shouldn't 500 or show
+        # "invalid"; send an existing member to their family home.
+        self._invitation(raw_code="reuse-link", recipient_email="joiner@example.com")
+        self.client.force_login(self.joiner)
+
+        first = self.client.get(self._link_url("reuse-link"))
+        self.assertEqual(first.status_code, 302)  # joined
+
+        second = self.client.get(self._link_url("reuse-link"))
+        self.assertRedirects(
+            second,
+            reverse("family_pool_home",
+                    kwargs={"family_slug": self.family.slug, "pool_slug": self.pool.slug}),
+            fetch_redirect_response=False,
+        )
+
     def test_valid_invite_reactivates_inactive_same_family_membership(self):
         self._invitation(raw_code="reactivate-code")
         membership = FamilyMembership.objects.create(

--- a/pickem/pickem_homepage/views.py
+++ b/pickem/pickem_homepage/views.py
@@ -726,10 +726,14 @@ def accept_invitation_for_user(request, raw_code):
 def render_invalid_invite(request, form=None, *, invite_code='', message=None):
     if form is None:
         form = JoinFamilyForm(initial={'code': invite_code} if invite_code else None)
-    form.add_error('code', message or "This invitation is invalid or unavailable.")
+    # Pass the error via context rather than form.add_error(): the link path
+    # (accept_invite_link) hands us an UNBOUND form, and add_error() raises
+    # AttributeError('cleaned_data') on an unvalidated form — which is what used
+    # to 500 the wrong-account and already-used invite cases.
     return render(request, 'pickem/join_family.html', {
         'form': form,
         'invite_code': invite_code,
+        'invite_error': message or "This invitation is invalid or unavailable.",
         'gameseason': get_season(),
     })
 
@@ -858,6 +862,27 @@ def accept_invite_link(request, invite_code):
             family_slug=invitation.family.slug,
             pool_slug=pool.slug,
         )
+
+    # The link didn't redeem. If it's simply spent/expired (no specific error)
+    # but the signed-in user is already a member of that family, send them home
+    # rather than showing an "invalid invite" page — re-clicking a used link is
+    # a normal thing to do.
+    if error is None:
+        spent = FamilyInvitation.objects.select_related('family').filter(
+            code_hash=hash_invite_code(invite_code),
+        ).first()
+        if spent and FamilyMembership.objects.filter(
+            family=spent.family, user=request.user,
+            status=FamilyMembership.Status.ACTIVE,
+        ).exists():
+            home_pool = spent.pool or get_default_active_pool_for_family(spent.family)
+            if home_pool:
+                messages.info(request, f"You're already in {spent.family.name}.")
+                return redirect(
+                    'family_pool_home',
+                    family_slug=spent.family.slug,
+                    pool_slug=home_pool.slug,
+                )
 
     form = JoinFamilyForm(initial={'code': invite_code})
     return render_invalid_invite(request, form, invite_code=invite_code, message=error)

--- a/pickem/pickem_superadmin/tests/test_email.py
+++ b/pickem/pickem_superadmin/tests/test_email.py
@@ -243,9 +243,9 @@ class InviteEmailSendingTests(TestCase):
         self.assertNotIn('<script>x</script>', params['html'])
         self.assertIn('&lt;script&gt;', params['html'])
         # Branding: styled CTA, brand colour, and the wordmark are present.
-        self.assertIn('Accept your invite', params['html'])
+        self.assertIn('Join the league', params['html'])
         self.assertIn('#0B3D91', params['html'])
-        self.assertIn("Family Pick'em", params['html'])
+        self.assertIn('Family Pick', params['html'])  # wordmark (curly apostrophe)
         # Plain-text alternative carries the raw (unescaped) name and the link.
         self.assertIn('<script>x</script>Crew', params['text'])
         self.assertIn('https://family-pickem.com/invite/xyz789', params['text'])


### PR DESCRIPTION
Addresses feedback on the email-invite flow.

1. **Invite email rebranded** to match the site — dark nav-style header (#0f172a) with the navy brand accent (#0B3D91) and a green eyebrow (#3CA455), plus warmer, less-generic copy ("Come join …", "Join the league"). The real logo image stays opt-in via `INVITE_EMAIL_LOGO_URL` because prod static is served from signed, expiring S3 URLs (unusable in delivered mail); without it, a styled wordmark shows.
2. **HTTP 500 clicking the link while signed in as another user** — the link path builds an *unbound* form and `render_invalid_invite` called `form.add_error()`, which raises `AttributeError('cleaned_data')` on an unvalidated form. Now the error is passed via context. **Re-accepting a spent link** 500'd the same way; an existing member who re-clicks is now redirected to their family home.
3. **Links were http://** behind Cloudflare — added `SECURE_PROXY_SSL_HEADER` so `build_absolute_uri` honours the edge's `X-Forwarded-Proto`, producing https links.

Tests: GET-link wrong-account + re-accept regression tests added; email branding test updated. 32 invite/email tests pass under `--settings=pickem.test_settings`.

**Note on the logo:** to show the actual logo image in emails, set `INVITE_EMAIL_LOGO_URL` to a stable public URL — the app's own `/static/` assets are signed S3 URLs that expire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)