### PR TITLE
fix(email): correct weekly picks branding and link targeting

### DIFF
--- a/pickem/pickem/settings.py
+++ b/pickem/pickem/settings.py
@@ -245,6 +245,10 @@ EMAIL_NOTIFICATION_SAFE_ALLOWLIST = [
 # falls back to a styled text wordmark when this is empty. Point it at a stable
 # public logo URL to show the image.
 INVITE_EMAIL_LOGO_URL = os.environ.get('INVITE_EMAIL_LOGO_URL', '').strip()
+WEEKLY_PICKS_EMAIL_LOGO_URL = os.environ.get(
+    'WEEKLY_PICKS_EMAIL_LOGO_URL',
+    INVITE_EMAIL_LOGO_URL,
+).strip()
 
 # Internationalization
 # https://docs.djangoproject.com/en/3.0/topics/i18n/

--- a/pickem/pickem_homepage/emailing.py
+++ b/pickem/pickem_homepage/emailing.py
@@ -9,6 +9,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 from pickem.utils import get_season
+from pickem_api.authz import LEGACY_FAMILY_SLUG
 from pickem_api.models import FamilyMembership, GameWeeks, GamesAndScores, Pool, Teams, UserProfile
 from pickem_superadmin.models import EmailNotificationCampaign
 from pickem_superadmin.models import EmailProviderSettings
@@ -21,6 +22,12 @@ except ImportError:  # pragma: no cover - dependency is installed in real envs
 
 logger = logging.getLogger(__name__)
 
+EMAIL_LINK_ROLE_ORDER = {
+    FamilyMembership.Role.MEMBER: 10,
+    FamilyMembership.Role.ADMIN: 20,
+    FamilyMembership.Role.OWNER: 30,
+}
+
 
 def _email_provider_config():
     config = EmailProviderSettings.current()
@@ -31,8 +38,18 @@ def _email_provider_config():
                 'provider': config.provider,
                 'api_key': api_key,
                 'from_email': config.from_email,
-            'reply_to': config.reply_to_email,
-            'source': 'database',
+                'reply_to': config.reply_to_email,
+                'source': 'database',
+            }
+        return None
+
+    if settings.RESEND_API_KEY and settings.RESEND_FROM_EMAIL:
+        return {
+            'provider': EmailProviderSettings.Provider.RESEND,
+            'api_key': settings.RESEND_API_KEY,
+            'from_email': settings.RESEND_FROM_EMAIL,
+            'reply_to': settings.RESEND_INVITE_REPLY_TO,
+            'source': 'environment',
         }
     return None
 
@@ -70,6 +87,10 @@ def _absolute_url(path):
 
 def _absolute_static_url(path):
     return _absolute_url(path)
+
+
+def _weekly_picks_email_logo_url():
+    return (getattr(settings, 'WEEKLY_PICKS_EMAIL_LOGO_URL', '') or '').strip()
 
 
 def _team_logo_map(slugs):
@@ -133,27 +154,44 @@ def _get_week_games(*, season, week, competition):
     return games
 
 
-def _default_active_pool_for_family(family):
+def _pool_queryset_for_family(family, *, season=None, competition=None):
+    queryset = Pool.objects.filter(
+        family=family,
+        status=Pool.Status.ACTIVE,
+    )
+    if season is not None:
+        queryset = queryset.filter(season=season)
+    if competition:
+        queryset = queryset.filter(competition=competition)
+    return queryset
+
+
+def _default_active_pool_for_family(family, *, season=None, competition=None):
     pool = (
-        Pool.objects.filter(
-            family=family,
-            status=Pool.Status.ACTIVE,
-            is_default=True,
+        _pool_queryset_for_family(
+            family,
+            season=season,
+            competition=competition,
         )
+        .filter(is_default=True)
         .order_by('-season', 'slug')
         .first()
     )
     if pool:
         return pool
     return (
-        Pool.objects.filter(family=family, status=Pool.Status.ACTIVE)
+        _pool_queryset_for_family(
+            family,
+            season=season,
+            competition=competition,
+        )
         .order_by('-season', 'slug')
         .first()
     )
 
 
-def _pick_link_membership(user):
-    memberships = (
+def _pick_link_membership(user, *, season=None, competition=None):
+    memberships = list(
         FamilyMembership.objects.select_related('family')
         .filter(
             user=user,
@@ -162,15 +200,33 @@ def _pick_link_membership(user):
         )
         .order_by('created_at', 'id')
     )
-    for membership in memberships:
-        pool = _default_active_pool_for_family(membership.family)
+
+    ordered_memberships = sorted(
+        memberships,
+        key=lambda membership: (
+            membership.family.slug == LEGACY_FAMILY_SLUG,
+            -EMAIL_LINK_ROLE_ORDER.get(membership.role, 0),
+            -(membership.created_at.timestamp() if membership.created_at else 0),
+            membership.id,
+        ),
+    )
+    for membership in ordered_memberships:
+        pool = _default_active_pool_for_family(
+            membership.family,
+            season=season,
+            competition=competition,
+        )
         if pool is not None:
             return membership, pool
     return None, None
 
 
-def _build_picks_link(user):
-    membership, pool = _pick_link_membership(user)
+def _build_picks_link(user, *, season=None, competition=None):
+    membership, pool = _pick_link_membership(
+        user,
+        season=season,
+        competition=competition,
+    )
     if membership is None or pool is None:
         return '', None, None
     return _absolute_url(
@@ -217,7 +273,7 @@ def _eligible_weekly_picks_users(campaign):
             if email_value not in safety_allowlist:
                 continue
         link, family, pool = _build_picks_link(user)
-        if not link or family is None or pool is None:
+        if not link:
             continue
         user._weekly_picks_link = link
         user._weekly_picks_family = family
@@ -281,10 +337,15 @@ def _weekly_picks_context(*, user, target, preview=False):
     if not games:
         return None
     picks_link = getattr(user, '_weekly_picks_link', '')
-    family = getattr(user, '_weekly_picks_family', None)
-    pool = getattr(user, '_weekly_picks_pool', None)
-    if not picks_link or family is None or pool is None:
-        picks_link, family, pool = _build_picks_link(user)
+    if not picks_link:
+        picks_link, family, pool = _build_picks_link(
+            user,
+            season=target['season'],
+            competition=target['competition'],
+        )
+    else:
+        family = getattr(user, '_weekly_picks_family', None)
+        pool = getattr(user, '_weekly_picks_pool', None)
     return {
         'user': user,
         'family': family,
@@ -294,7 +355,7 @@ def _weekly_picks_context(*, user, target, preview=False):
         'season': target['season'],
         'picks_link': picks_link,
         'site_url': _site_base_url(),
-        'logo_url': _absolute_static_url('/static/images/logo.png'),
+        'logo_url': _weekly_picks_email_logo_url(),
         'preview': preview,
     }
 
@@ -406,17 +467,6 @@ def send_due_email_campaigns(*, now=None, force_weekly_picks=False):
             'skipped': skipped,
         }],
     }
-
-    if settings.RESEND_API_KEY and settings.RESEND_FROM_EMAIL:
-        return {
-            'provider': EmailProviderSettings.Provider.RESEND,
-            'api_key': settings.RESEND_API_KEY,
-            'from_email': settings.RESEND_FROM_EMAIL,
-            'reply_to': settings.RESEND_INVITE_REPLY_TO,
-            'source': 'environment',
-        }
-    return None
-
 
 def resend_invite_email_is_configured():
     config = _invite_email_config()

--- a/pickem/pickem_homepage/templates/emails/weekly_picks_available.html
+++ b/pickem/pickem_homepage/templates/emails/weekly_picks_available.html
@@ -16,7 +16,7 @@
         <div style="font-size:14px; color:#1d4ed8; font-weight:700; margin-bottom:6px;">Quick link</div>
         <div style="font-size:15px; color:#334155; line-height:1.6; margin-bottom:14px;">
           {% if pool %}Pool: {{ pool.name }}<br>{% endif %}
-          Picks are opened from your earliest joined active family.
+          Open your Week {{ week }} picks page directly.
         </div>
         <a href="{{ picks_link }}" style="display:inline-block; background:#0b3d91; color:#ffffff; text-decoration:none; font-weight:700; padding:12px 18px; border-radius:999px;">Open picks page</a>
       </div>

--- a/pickem/pickem_homepage/templates/emails/weekly_picks_available.txt
+++ b/pickem/pickem_homepage/templates/emails/weekly_picks_available.txt
@@ -2,9 +2,9 @@ Family Pick'em
 
 Picks for Week {{ week }} are available.
 
-{% if family %}Family: {{ family.name }}{% endif %}
-{% if pool %}Pool: {{ pool.name }}{% endif %}
 Picks page: {{ picks_link }}
+{% if pool %}Pool: {{ pool.name }}{% endif %}
+Open your Week {{ week }} picks page directly.
 
 Games:
 {% for game in games %}

--- a/pickem/pickem_superadmin/tests/test_email.py
+++ b/pickem/pickem_superadmin/tests/test_email.py
@@ -309,6 +309,7 @@ class InviteEmailSendingTests(TestCase):
     SITE_BASE_URL='https://family-pickem.test',
     EMAIL_NOTIFICATION_SAFE_ALLOWLIST_ONLY=True,
     EMAIL_NOTIFICATION_SAFE_ALLOWLIST=['jdagostino2@gmail.com'],
+    WEEKLY_PICKS_EMAIL_LOGO_URL='https://cdn.example.test/fp-logo.png',
 )
 class WeeklyPicksCampaignTests(TestCase):
     def setUp(self):
@@ -433,7 +434,7 @@ class WeeklyPicksCampaignTests(TestCase):
         self.assertIn('Picks for Week 1 are available', params['subject'])
         self.assertIn('https://cdn.example.test/bears.png', params['html'])
         self.assertIn('https://cdn.example.test/packers.png', params['html'])
-        self.assertIn('https://family-pickem.test/static/images/logo.png', params['html'])
+        self.assertIn('https://cdn.example.test/fp-logo.png', params['html'])
         self.assertIn(
             'https://family-pickem.test/families/dagostino/pools/main-pool/picks/',
             params['html'],
@@ -442,6 +443,52 @@ class WeeklyPicksCampaignTests(TestCase):
         self.assertEqual(self.campaign.last_sent_season, 2627)
         self.assertEqual(self.campaign.last_sent_week, 1)
         self.assertEqual(self.campaign.last_sent_count, 1)
+
+    def test_campaign_prefers_non_legacy_commissioner_family_for_multi_family_user(self):
+        legacy_family, _ = Family.objects.get_or_create(
+            slug='legacy-family-league',
+            defaults={'name': 'Legacy'},
+        )
+        Pool.objects.create(
+            family=legacy_family,
+            name='Legacy Pool',
+            slug='legacy-pool',
+            season=2627,
+            competition='nfl',
+            is_default=True,
+        )
+        FamilyMembership.objects.create(
+            family=legacy_family,
+            user=self.allowed_user,
+            role=FamilyMembership.Role.MEMBER,
+        )
+        test_family = Family.objects.create(name='Test Family', slug='test')
+        Pool.objects.create(
+            family=test_family,
+            name='Test Pool',
+            slug='pickem-pool',
+            season=2627,
+            competition='nfl',
+            is_default=True,
+        )
+        FamilyMembership.objects.create(
+            family=test_family,
+            user=self.allowed_user,
+            role=FamilyMembership.Role.OWNER,
+        )
+        self._seed_week_one()
+        september_9_2026 = timezone.make_aware(datetime(2026, 9, 9, 13, 5))
+        resend_mock = Mock()
+        resend_mock.Emails.send.return_value = {'id': 'weekly_email_2'}
+
+        with patch('pickem_homepage.emailing.resend', new=resend_mock):
+            send_due_email_campaigns(now=september_9_2026)
+
+        params = resend_mock.Emails.send.call_args.args[0]
+        self.assertIn(
+            'https://family-pickem.test/families/test/pools/pickem-pool/picks/',
+            params['html'],
+        )
 
 
 class EmailEnvironmentFallbackTests(TestCase):


### PR DESCRIPTION
## Summary
- fix weekly picks emails to use a stable configurable logo URL
- target the direct tenant picks page instead of falling back to the family picker for multi-family users
- add regression coverage for multi-family targeting and logo rendering

## Testing
- source venv/bin/activate && cd pickem && python manage.py test pickem_superadmin.tests.test_email.WeeklyPicksCampaignTests --settings=pickem.test_settings
