### PR TITLE
feat(superadmin): email provider Edit button (+ per-step-jobs design spec)

### DIFF
--- a/docs/superpowers/specs/2026-07-17-per-step-jobs-and-run-logs-design.md
+++ b/docs/superpowers/specs/2026-07-17-per-step-jobs-and-run-logs-design.md
@@ -1,0 +1,86 @@
+# Per-step jobs, per-run logs, and email edit — design
+
+**Date:** 2026-07-17
+**Apps:** `pickem_api` (scheduler, models), `pickem_superadmin` (jobs/logs/email pages, log handler)
+**Status:** Approved design (user confirmed the key fork), pre-implementation
+
+## Motivation (user feedback)
+
+1. `/superadmin/email/` "Current status" should have an **Edit** button to edit current values, API key masked/never exposed.
+2. Retire the `update_all` umbrella job — register **each pipeline step individually** with its own cadence/enable rules.
+3. Logs should carry a **unique key per job + per run** so the jobs page can link each run to its logs.
+4. The jobs **status endpoint** must reflect the per-step model.
+
+## Key decision (confirmed with user)
+
+The 9 pipeline steps have **hard data dependencies** (`update_records` → `update_games` → `update_missed_picks` → `update_picks` → `update_standings` → `update_weekly_winners`/`update_rankings`/`update_season_winners` → `update_stats`). So:
+
+- **Order is fixed by code**, shown read-only on the page. **No user reordering** (it would corrupt scoring).
+- Per-step controls are **cadence (interval) + enable/disable** only.
+- Execution stays a **single coordinated ordered pass** (one APScheduler orchestrator job, `max_instances=1`, `coalesce=True`) so steps never run out of order or concurrently. On each tick, each enabled step runs **only when its own interval is due**.
+
+## Architecture
+
+### Scheduler (`pickem_api/scheduler.py`)
+
+- Replace `JOB_REGISTRY` (`update_all`, `update_records`) with `PIPELINE_STEPS`: the ordered list of the 9 step command names, each with a `default_minutes` (records 30, stats 5, rest 1) and a display label.
+- Retire `run_update_all`/`run_update_records`. Add **`run_pipeline_tick()`** — the single orchestrator job, registered on a 1-minute `IntervalTrigger`, `max_instances=1`, `coalesce=True`. It:
+  1. `ScheduledJobConfig.seed_from_pipeline()` (one row per step; `update_records`/`update_stats` get their defaults).
+  2. Iterates `PIPELINE_STEPS` **in order**. For each step whose config is `enabled` and **due** (`last_run_at is None or now - last_run_at >= interval_minutes`):
+     - Create a `JobRun` (uuid `run_id`, `job_id=step`, `started_at`).
+     - Set a context (`run_id`, `job_id`) via `contextvars` so the log handler stamps rows (see Logging).
+     - `mark_job_started(step)`, run the step command via `call_command_logged(step, logger_name=f'django.job.{step}')`, capturing stdout/stderr into the per-step logger.
+     - On finish: set `JobRun.finished_at`, `status` (success/error), `duration_ms`, `exception`; update `ScheduledJobConfig.last_run_at`; `mark_job_finished(step)`; clear the context.
+  - A step's failure is logged and does NOT stop later steps (same tolerance as today's `update_all`).
+- Keep the daily `prune_superadmin_logs` job (unchanged) and add a companion `prune_job_runs` (age out `JobRun` rows, mirroring log retention).
+- `reschedule_live` is no longer per-APScheduler-job (there's one orchestrator); schedule edits just write `ScheduledJobConfig` and the next tick honors them — so `reschedule_live` becomes a no-op/removed and the jobs-save view no longer calls it.
+
+### Models
+
+- **`ScheduledJobConfig`** (`pickem_api`): add `last_run_at` (nullable DateTime). `job_id` now holds a step name. Replace `seed_from_registry` with `seed_from_pipeline` seeding one row per `PIPELINE_STEPS` entry (get_or_create; preserves edits). A `display_label` lookup comes from `PIPELINE_STEPS`.
+- **`JobRun`** (`pickem_api`, new): `run_id` (UUIDField, unique, db_index), `job_id` (CharField, db_index), `started_at`, `finished_at` (null), `status` (choices: running/success/error, default running), `duration_ms` (null), `exception` (TextField, null). Ordering `-started_at`. Migration.
+- **`SuperAdminLogEntry`** (`pickem_superadmin`): add `run_id` (UUIDField, null, db_index) and `job_id` (CharField, null, db_index). Migration.
+- **`RunningJobMarker`**: unchanged shape; now written per step by the orchestrator (already keyed on `job_id`).
+
+### Logging (`pickem_superadmin/logging.py`, `pickem_api/log_bridge.py`)
+
+- `log_bridge.py`: a module-level `contextvars.ContextVar` pair (`_current_run_id`, `_current_job_id`). `call_command_logged(command, *, logger_name=None)` gains an optional per-step `logger_name` (default keeps `pickem_api.pipeline` for ad-hoc/manual). The orchestrator sets the contextvars around each step; the stdout `LoggerWriter` emits under `django.job.<step>`.
+- `DatabaseLogHandler.emit`: read the contextvars and set `run_id`/`job_id` on the `SuperAdminLogEntry` it writes. So EVERY log line during a step run (the stdout bridge AND the command's own `pickem_api.*` warnings) is stamped with the run.
+- `settings.LOGGING`: add `django.job` to the captured loggers at `SUPERADMIN_LOG_APP_LEVEL` (INFO) with the DB handler, `propagate: False`. (Root stays WARNING; `django.job.*` must be explicitly captured or it'd fall to root.)
+
+### Jobs page (`pickem_superadmin/views/jobs.py`, `templates/superadmin/jobs.html`)
+
+- "Registered jobs"/"Schedules" become one **per-step table**: step label (read-only, in pipeline order), interval input, enabled toggle, last run. Saved through the existing `save_matrix` pattern (now over all step rows). `jobs_schedule_save` audits + writes configs (no `reschedule_live`).
+- "Run history" reads **`JobRun`** (not `DjangoJobExecution`): per-step rows with status/duration/exception, each with a **"logs" link → `/superadmin/logs/?run_id=<uuid>`**.
+- The manual "Queue a run" keeps working but queues an individual step (allowlist = `PIPELINE_STEPS` names + existing `QUEUEABLE_COMMANDS` extras).
+
+### Status endpoint (`jobs_status`)
+
+- Returns `running` from per-step `RunningJobMarker`s (already keyed by job_id) + `health`. The health check adapts to the orchestrator (a recent `JobRun` or a scheduled orchestrator tick = alive). The jobs page poll shows the live step label.
+
+### Logs page (`pickem_superadmin/views/logs.py`, `templates/superadmin/logs.html`)
+
+- Add a **`run_id`** filter (exact) and a **`job`** filter (`job_id` icontains), plus a `job`/`run` column. A `?run_id=<uuid>` deep-link shows exactly that run's lines.
+
+### Email edit (`templates/superadmin/email.html`)
+
+- "Current status" card gets an **Edit** button that reveals the pre-filled provider form (JS show/hide; the form already exists and pre-fills via the ModelForm instance). API key stays masked in status and blank-to-keep in the form (write-only field; never rendered with the real value). No view change needed beyond the toggle.
+
+## Testing (correctness-critical — this drives live scoring)
+
+- Orchestrator: steps run in dependency order; a step runs only when due (interval respected via `last_run_at`); disabled steps skip; a failing step doesn't stop later steps; `JobRun` + `last_run_at` recorded; `RunningJobMarker` set/cleared per step. (Unit-test the tick logic without a live scheduler thread.)
+- Logging: a step run stamps `run_id`/`job_id` on log rows (handler reads contextvars); `django.job.<step>` captured at INFO; `run_id` filter on the logs page returns exactly that run.
+- Jobs page: per-step schedule editor saves + audits; run-history links carry the run_id; auth-coverage for any new/changed URL.
+- Status endpoint: reports the running step.
+- Email: Edit toggle present; key never in the rendered form value.
+
+## Migration / rollout notes
+
+- `ScheduledJobConfig` rows for old `update_all`/`update_records` become the new per-step rows via `seed_from_pipeline` (old `update_all` row is ignored/removed). `update_records`'s 30-min cadence is preserved as its step default.
+- New migrations: `pickem_api` (ScheduledJobConfig.last_run_at, JobRun), `pickem_superadmin` (SuperAdminLogEntry.run_id/job_id). Prod applies via the initContainer.
+- No data destruction; historical `DjangoJobExecution` rows remain (superseded by `JobRun` going forward).
+
+## Out of scope
+
+- User-defined step ordering (fixed by dependencies).
+- Cron-expression schedules (interval-minutes only, consistent with the existing editor).

--- a/pickem/pickem_superadmin/templates/superadmin/email.html
+++ b/pickem/pickem_superadmin/templates/superadmin/email.html
@@ -5,7 +5,7 @@
 {% block content %}
   <div class="grid gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(280px,1fr)]">
     <div class="space-y-4">
-    <div class="sa-card p-4">
+    <div class="sa-card p-4{% if not form.errors %} hidden{% endif %}" id="provider-settings-card">
       <div class="sa-h2 mb-1">Provider settings</div>
       <p class="mb-4 text-[12px] text-[#667085]">
         Invite emails only send when provider config is enabled, a from address is set, and an API key is stored.
@@ -157,6 +157,7 @@
           <span class="text-[#667085]">API key</span>
           <span class="sa-mono">{% if email_settings.has_api_key %}{{ email_settings.masked_api_key }}{% else %}unset{% endif %}</span>
         </div>
+        <button type="button" id="edit-provider-btn" class="sa-btn sa-btn-default sa-btn-sm mt-1">Edit provider settings</button>
         <div class="pt-3 text-[12px] font-semibold uppercase tracking-[0.12em] text-[#667085]">Weekly campaign</div>
         <div class="flex items-center justify-between gap-3">
           <span class="text-[#667085]">Campaign</span>
@@ -203,4 +204,20 @@
       </div>
     </div>
   </div>
+  <script>
+    // "Edit provider settings" reveals the (pre-filled) provider form. It stays
+    // hidden by default so Current status reads clean; the API key is never
+    // rendered into the form (write-only — blank means keep the stored key).
+    (function () {
+      var btn = document.getElementById('edit-provider-btn');
+      var card = document.getElementById('provider-settings-card');
+      if (!btn || !card) return;
+      btn.addEventListener('click', function () {
+        card.classList.remove('hidden');
+        card.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        var first = card.querySelector('select, input');
+        if (first) first.focus();
+      });
+    })();
+  </script>
 {% endblock %}

--- a/pickem/pickem_superadmin/tests/test_email.py
+++ b/pickem/pickem_superadmin/tests/test_email.py
@@ -58,6 +58,18 @@ class EmailSettingsViewTests(TestCase):
         self.assertContains(response, 'Enable invite emails')
         self.assertContains(response, 'Weekly picks campaign')
 
+    def test_current_status_has_edit_button_and_never_exposes_key(self):
+        settings_obj = EmailProviderSettings.load()
+        settings_obj.set_api_key('re_super_secret_ABC123')
+        settings_obj.save()
+
+        response = self.client.get(reverse('superadmin:email_settings'))
+
+        self.assertContains(response, 'Edit provider settings')
+        # Status shows a masked key; the plaintext key is never rendered anywhere.
+        self.assertContains(response, settings_obj.masked_api_key)
+        self.assertNotContains(response, 're_super_secret_ABC123')
+
     def test_post_saves_encrypted_settings_and_audits_without_plaintext_key(self):
         response = self.client.post(
             reverse('superadmin:email_settings'),


### PR DESCRIPTION
**Email settings (#1 of the jobs/email feedback):** the Provider settings form is now hidden by default, with an **Edit provider settings** button in the Current status card that reveals the pre-filled form. The API key is masked in status and never rendered into the form (write-only; blank keeps the stored key). Test asserts the button is present and the plaintext key is never in the response.

Also includes `docs/superpowers/specs/2026-07-17-per-step-jobs-and-run-logs-design.md` — the approved design for the larger follow-up (retire `update_all`, register each pipeline step individually with its own cadence, per-run log linking, status endpoint), which I'll implement in a separate PR since it reshapes the live scoring scheduler and needs heavy testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Edit provider settings” control to the email status page.
  * Provider settings remain hidden until requested, with automatic scrolling to the editable form.
  * API keys are masked and remain protected when the form is displayed.

* **Documentation**
  * Documented a redesigned pipeline scheduling and observability experience with per-step configuration, run tracking, and linked logs.
  * Defined updated status, history, filtering, and migration behavior for the superadmin jobs interface.

* **Tests**
  * Added coverage confirming the edit control appears and plaintext API keys are never exposed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->