### PR TITLE
fix: CodeRabbit follow-ups from #78

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,9 @@
 # Family Pickem — TODO
 
-Audited 2026-07-17: every open item below was verified against the current
-code. Finished and stale items are collapsed under **Done** at the bottom.
+Audited 2026-07-17: every code-related open item below was verified against
+the current code (manual infra chores, like the AWS Secrets Manager cleanup,
+can't be — they're marked as manual). Finished and stale items are collapsed
+under **Done** at the bottom.
 
 ## Active Backlog
 

--- a/pickem/pickem_api/management/commands/update_weekly_winners.py
+++ b/pickem/pickem_api/management/commands/update_weekly_winners.py
@@ -53,9 +53,12 @@ class Command(BaseCommand):
         stats_provider = EspnGameStatsProvider()
         awarded = 0
         # Skip pools of deactivated (soft-deleted) families — no bonuses are
-        # awarded while a family is inactive.
+        # awarded while a family is inactive — and other seasons' pools,
+        # which could never award anything for this season anyway.
         for pool in Pool.objects.filter(
-            status=Pool.Status.ACTIVE, family__status=Family.Status.ACTIVE
+            status=Pool.Status.ACTIVE,
+            season=season,
+            family__status=Family.Status.ACTIVE,
         ):
             try:
                 result = award_weekly_winners(

--- a/pickem/pickem_api/migrations/0089_rename_seasoned_default_pool_names.py
+++ b/pickem/pickem_api/migrations/0089_rename_seasoned_default_pool_names.py
@@ -6,6 +6,10 @@ and competition again — "NFL Pick'em - 2026 - 2027 - 2026-2027 NFL". The
 default is now "Pick'em Pool"; this renames only pools whose name exactly
 matches the old default for their own season, so any commissioner-customized
 name is left alone.
+
+The reverse is a no-op: the forward pass doesn't record which rows it
+changed, so a real reversal would clobber every pool legitimately named
+"Pick'em Pool" (including ones created after this migration ran).
 """
 
 from django.db import migrations
@@ -28,15 +32,6 @@ def rename_default_pools(apps, schema_editor):
             pool.save(update_fields=['name', 'updated_at'])
 
 
-def restore_seasoned_names(apps, schema_editor):
-    Pool = apps.get_model('pickem_api', 'Pool')
-    for pool in Pool.objects.filter(name=NEW_DEFAULT_NAME):
-        old_name = old_default_name(pool.season)
-        if old_name:
-            pool.name = old_name
-            pool.save(update_fields=['name', 'updated_at'])
-
-
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -44,5 +39,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(rename_default_pools, restore_seasoned_names),
+        migrations.RunPython(rename_default_pools, migrations.RunPython.noop),
     ]

--- a/pickem/pickem_homepage/views.py
+++ b/pickem/pickem_homepage/views.py
@@ -1413,20 +1413,22 @@ def family_pool_admin_delete_family(request, family_slug, pool_slug):
     tenant_context = request.tenant_context
     family = tenant_context.family
     confirmed_name = (request.POST.get('confirm_name') or '').strip()
-    if confirmed_name != family.name:
-        messages.error(
-            request,
-            "The name you typed doesn't exactly match the family name, so "
-            "nothing was deactivated.",
-        )
-        return redirect(
-            'family_pool_admin_settings',
-            family_slug=family.slug,
-            pool_slug=tenant_context.pool.slug,
-        )
 
     with transaction.atomic():
         locked_family = Family.objects.select_for_update().get(id=family.id)
+        # Compare against the locked row, not the request-time snapshot — a
+        # concurrent rename must not let a stale name deactivate the family.
+        if confirmed_name != locked_family.name:
+            messages.error(
+                request,
+                "The name you typed doesn't exactly match the family name, so "
+                "nothing was deactivated.",
+            )
+            return redirect(
+                'family_pool_admin_settings',
+                family_slug=family.slug,
+                pool_slug=tenant_context.pool.slug,
+            )
         previous_status = locked_family.status
         if previous_status == Family.Status.ACTIVE:
             locked_family.status = Family.Status.INACTIVE


### PR DESCRIPTION
Post-merge fixes for CodeRabbit's (rate-limit-delayed) review of #78 — each finding verified against the code before applying:

1. **Migration `0089` reverse is now a no-op.** The forward rename doesn't record which rows it touched, so the old reverse would have renamed every pool legitimately called "Pick'em Pool" (including post-migration ones). Forward behavior unchanged; already applied in prd.
2. **Deactivation confirm checked under the row lock.** The typed family name is now compared against the `select_for_update()`-locked row, so a concurrent rename can't let a stale name deactivate the family.
3. **`update_weekly_winners` filters pools by season**, matching `update_missed_picks`/`update_standings` — stops iterating archived-season pools (e.g. FFFPL's 2526 pool) every minute.
4. **TODO.md** audit wording narrowed to code-verifiable items.

Full suite: 573 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Weekly winners are now awarded only from pools in the current season.
  * Family deletion confirmation now validates against the latest saved family name, preventing accidental deactivation when details have changed.
  * Default pool names are updated without overwriting customized names.

* **Documentation**
  * Clarified which open items have been verified and which require manual infrastructure work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->