### PR TITLE
fix(monitoring): disable OpenCost until token has metrics:read

### DIFF
--- a/infra/grafana-k8s-monitoring/values.yaml
+++ b/infra/grafana-k8s-monitoring/values.yaml
@@ -83,8 +83,12 @@ hostMetrics:
   energyMetrics:
     enabled: true
 
+# Cost metrics disabled: OpenCost queries Grafana Cloud Prometheus to compute
+# allocation, which needs a token with metrics:read. The current access policy
+# is write-only, so re-enable this (and opencost.deploy below) once the token
+# has the read scope.
 costMetrics:
-  enabled: true
+  enabled: false
   collector: alloy-metrics
 
 clusterEvents:
@@ -156,7 +160,8 @@ telemetryServices:
   kepler:
     deploy: true
   opencost:
-    deploy: true
+    # Disabled until the access token gains metrics:read (see costMetrics above).
+    deploy: false
     metricsSource: grafana-cloud-metrics
     opencost:
       exporter:


### PR DESCRIPTION
Follow-up to #80. OpenCost crash-loops because it queries Grafana Cloud Prometheus to compute cost allocation, which needs a token with `metrics:read`; the current write-only access token returns `401 invalid scope requested`.

Disables `costMetrics` and `telemetryServices.opencost.deploy` until the access policy gains the read scope. All other telemetry (metrics, logs, events, traces, profiles) is unaffected. Render-verified: no OpenCost workload produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)