### PR TITLE
Fix/css signed s3 cachebuster

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,16 @@ npm run build:css
 npm run build:prod
 ```
 
+> ⚠️ **NEVER append a `?v=...` cache-buster query string to a `{% static %}` URL.**
+> In production `{% static %}` returns an **S3 querystring-signed URL** (already
+> carrying `?X-Amz-...` params). Adding `?v=...` produces a second `?`, corrupts
+> the signature, and the browser blocks the asset — the whole site renders
+> **completely unstyled**. Link the stylesheet plainly:
+> `<link rel="stylesheet" href="{% static 'css/tailwind.css' %}">`.
+> The signature already makes prd URLs unique per render, so a cache-buster buys
+> nothing. This has regressed twice (commits `dff2d03`, then again in the AI-recaps
+> change) — do not reintroduce it.
+
 ## Project Architecture
 
 ### Django Apps Structure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,6 +288,16 @@ build the stylesheet with `npm run build:css` (watch) or `npm run build:prod`
 (minified). The compiled `tailwind.css` is committed and served, so new utility
 classes require a rebuild before commit.
 
+> ⚠️ **NEVER append a `?v=...` cache-buster query string to a `{% static %}` URL.**
+> In production `{% static %}` returns an **S3 querystring-signed URL** (already
+> carrying `?X-Amz-...` params). Adding `?v=...` produces a second `?`, corrupts
+> the signature, and the browser blocks the asset — the whole site renders
+> **completely unstyled**. Link the stylesheet plainly:
+> `<link rel="stylesheet" href="{% static 'css/tailwind.css' %}">`.
+> The signature already makes prd URLs unique per render, so a cache-buster buys
+> nothing. This has regressed twice (commits `dff2d03`, then again in the AI-recaps
+> change) — do not reintroduce it.
+
 ## URL Patterns
 
 Key routes (see `pickem/urls.py` and `pickem_homepage/views.py`):

--- a/pickem/pickem_homepage/templates/pickem/base.html
+++ b/pickem/pickem_homepage/templates/pickem/base.html
@@ -30,7 +30,7 @@
     {% load static %}
     <link rel="shortcut icon" type="image/png" href="{% static 'images/windowlogo.png' %}">
     <!-- Tailwind CSS -->
-    <link rel="stylesheet" href="{% static 'css/tailwind.css' %}?v=ai-cards-2">
+    <link rel="stylesheet" href="{% static 'css/tailwind.css' %}">
 </head>
 
 <body class="bg-gray-50 dark:bg-bg-dark transition-colors duration-200">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stylesheet loading in production by removing an incompatible cache-busting query parameter from the Tailwind CSS link.
  * Prevented signed asset URLs from being corrupted, ensuring pages render with their intended styling.

* **Documentation**
  * Added guidance on correctly referencing Django static assets and avoiding cache-busting query strings on signed URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->