### PR TITLE
chore: pause grafana-k8s-monitoring ArgoCD app

### DIFF
--- a/infra/argocd/applications-disabled/grafana-k8s-monitoring.yaml
+++ b/infra/argocd/applications-disabled/grafana-k8s-monitoring.yaml
@@ -1,3 +1,18 @@
+# PAUSED 2026-07-21: moved out of infra/argocd/applications/ (the root
+# app-of-apps only watches that directory, non-recursively) so the root app
+# prunes this Application on next sync -- cascade-deleting the k8s-monitoring
+# Helm release and everything it owns in the `monitoring` namespace, via the
+# resources-finalizer below.
+#
+# Reason: the k8s node is too small for this stack right now; it was causing
+# noticeable performance degradation. Not deleted -- config is untouched, just
+# out of the reconciled path.
+#
+# To re-enable (e.g. after moving to bigger hardware):
+#   git mv infra/argocd/applications-disabled/grafana-k8s-monitoring.yaml \
+#          infra/argocd/applications/grafana-k8s-monitoring.yaml
+# then commit + push to main; the root app will recreate it and ArgoCD will
+# reinstall the chart on its next sync.
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:


### PR DESCRIPTION
## Summary
- The k8s node is too small for the Grafana k8s-monitoring stack right now and it's causing performance degradation.
- Moves `infra/argocd/applications/grafana-k8s-monitoring.yaml` to a sibling `infra/argocd/applications-disabled/` directory. The root app-of-apps only watches `infra/argocd/applications/` (non-recursive), so on next sync it will prune the child `grafana-k8s-monitoring` Application -- cascade-deleting the Helm release and everything it owns in the `monitoring` namespace, via the existing `resources-finalizer`.
- Config is **not deleted**, just moved out of the reconciled path, so it can be re-enabled later (move the file back to `infra/argocd/applications/`) once on hardware that can carry it. Instructions are in a comment at the top of the file.

## Test plan
- [x] No application code changed -- infra manifest move only
- [ ] Confirm after merge: root app prunes `grafana-k8s-monitoring` Application, `monitoring` namespace resources are removed, node load drops

🤖 Generated with [Claude Code](https://claude.com/claude-code)