### PR TITLE
perf: avoid picks review lock N+1

### DIFF
--- a/pickem/pickem_homepage/templates/pickem/picks.html
+++ b/pickem/pickem_homepage/templates/pickem/picks.html
@@ -400,6 +400,7 @@
                     {% if pick_slugs and not auth_required %}
                         {% for game in game_list %}
                         {% if game.slug in pick_slugs %}
+                        {% with locked=game|is_game_locked_for_pool:pool %}
                             {% with pool.id|addstr:"-"|addstr:user.id|addstr:"-"|addstr:game.id as template %}
                                 {% if template in pick_ids %}
                                 <div data-submitted-game="{{ game.id }}" class="bg-surface-light dark:bg-surface rounded-xl p-5 border border-border-light dark:border-border-subtle hover:border-primary/50 transition-all duration-200 space-y-4">
@@ -508,7 +509,7 @@
 
                                     <!-- Edit/Lock Actions -->
                                     <div class="pt-3 border-t border-border-light dark:border-border-subtle">
-                                        {% if not game|is_game_locked_for_pool:pool %}
+                                        {% if not locked %}
                                         {% for p in picks %}
                                             {% if p.slug == game.slug %}
                                         {% for away_team in wins_losses %}
@@ -568,6 +569,7 @@
                                 </div>
                                 {% endif %}
                             {% endwith %}
+                        {% endwith %}
                         {% endif %}
                         {% endfor %}
                     {% else %}

--- a/pickem/pickem_homepage/tests.py
+++ b/pickem/pickem_homepage/tests.py
@@ -1233,7 +1233,7 @@ class TenantPickFlowIsolationTests(TestCase):
         for game in GamesAndScores.objects.filter(
             gameseason=2526, gameWeek="1", competition="nfl",
         ):
-            self._create_pick(user=self.member, pool=self.smith_pool, pick=self.game.homeTeamSlug, game=game)
+            self._create_pick(user=self.member, pool=self.smith_pool, pick=game.homeTeamSlug, game=game)
         self.client.force_login(self.member)
 
         from pickem import utils as pickem_utils

--- a/pickem/pickem_homepage/tests.py
+++ b/pickem/pickem_homepage/tests.py
@@ -1227,6 +1227,13 @@ class TenantPickFlowIsolationTests(TestCase):
                 awayTeamSlug="ari",
                 awayTeamName="Arizona Cardinals",
             )
+        # Put every game into the submitted-picks loop too. The available-game
+        # loop is already protected by a `{% with locked=... %}`; this is the
+        # second render path issue #98 covers.
+        for game in GamesAndScores.objects.filter(
+            gameseason=2526, gameWeek="1", competition="nfl",
+        ):
+            self._create_pick(user=self.member, pool=self.smith_pool, pick=self.game.homeTeamSlug, game=game)
         self.client.force_login(self.member)
 
         from pickem import utils as pickem_utils


### PR DESCRIPTION
## Summary
- compute the pool-aware lock state once per submitted pick card
- reuse that value for the edit/locked action gate
- add a regression test covering the submitted-picks loop

## Validation
- `python manage.py check`
- compile `pickem/picks.html` through Django

The shared-cache portion of #98 remains dependent on shared cache infrastructure; this PR ships the independent template N+1 fix.

Closes #98