### PR TITLE
perf: reuse database connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ User → userStats (One-to-One)
 |----------|-------------|----------|
 | `SECRET_KEY` | Django secret key | Yes |
 | `DATABASE_URL` | PostgreSQL connection string | Yes |
+| `DATABASE_CONN_MAX_AGE` | Seconds to reuse a database connection before reconnecting (defaults to `60`) | No |
 | `GOOGLE_OAUTH2_KEY` | Google OAuth client ID | Yes |
 | `GOOGLE_OAUTH2_SECRET` | Google OAuth client secret | Yes |
 | `DEBUG` | Enable debug mode | No |

--- a/pickem/pickem/settings.py
+++ b/pickem/pickem/settings.py
@@ -185,6 +185,16 @@ else:
         }
     }
 
+# Reuse PostgreSQL connections across requests to avoid a new TCP/database
+# handshake for every page load. Django verifies a reused connection once per
+# request, which lets it recover cleanly after a database restart or failover.
+# The lifetime remains configurable for deployment environments that need a
+# shorter pool window.
+DATABASES['default'].update({
+    'CONN_MAX_AGE': int(os.environ.get('DATABASE_CONN_MAX_AGE', '60')),
+    'CONN_HEALTH_CHECKS': True,
+})
+
 # Password validation
 # https://docs.djangoproject.com/en/3.0/ref/settings/#auth-password-validators
 


### PR DESCRIPTION
## Summary
- reuse database connections for 60 seconds by default
- check connections before reuse so database restarts and failovers recover cleanly
- allow `DATABASE_CONN_MAX_AGE` to tune the reuse window

## Validation
- `python manage.py check`
- `python manage.py check --settings=pickem.test_settings`

Closes #96