### PR TITLE
fix: shorten ArgoCD repo-server cache TTL to un-stick auto-sync

### DIFF
--- a/infra/argocd/values.yaml
+++ b/infra/argocd/values.yaml
@@ -8,6 +8,13 @@ configs:
   params:
     # Run insecure (TLS terminated at ingress)
     server.insecure: true
+    # Default repo-content cache TTL is 24h, so the routine 3-minute
+    # reconciliation loop (timeout.reconciliation, argocd-cm) was comparing
+    # against day-old cached git content -- every release needed a manual
+    # `argocd.argoproj.io/refresh=hard` (which explicitly bypasses this
+    # cache) to actually notice a new commit. A short TTL here means normal
+    # reconciliation picks up new commits within about one cycle on its own.
+    reposerver.repo.cache.expiration: 60s
 
 server:
   ingress:


### PR DESCRIPTION
## Summary

Every release this session (0.0.181, 0.0.182, 0.0.183) needed a manual
\`kubectl annotate application root -n argocd argocd.argoproj.io/refresh=hard\`
before the prd deployment actually rolled to the new version, despite
\`update_argocd\` successfully pushing the targetRevision bump to \`main\`
every time.

Diagnosed via the application-controller's own logs: the 3-minute
reconciliation loop (\`timeout.reconciliation\`, \`argocd-cm\`) was running
exactly on schedule the whole time and reporting the app "Synced" -- so
the lag was never the reconciliation interval. \`reposerver.repo.cache.expiration\`
had no explicit override, defaulting to a much longer TTL, so routine
reconciliation kept comparing against stale cached git content. Only a
hard refresh -- which explicitly bypasses that cache -- ever picked up a
new commit.

## Fix

One line in \`infra/argocd/values.yaml\` (ArgoCD is self-managed via
GitOps through this file + the \`argocd\` Application, so this can't be a
direct \`kubectl patch\` -- that would just get reverted by selfHeal):

\`\`\`yaml
reposerver.repo.cache.expiration: 60s
\`\`\`

## Test plan
- [x] Confirmed via controller logs that \`timeout.reconciliation\` (180s) was already firing on schedule -- ruled out that being the bottleneck before changing it
- [x] Confirmed ArgoCD's own Application manages itself via \`infra/argocd/values.yaml\` with \`selfHeal: true\`, so this had to go through git
- [ ] After merge: confirm a future release rolls without a manual hard-refresh (can't fully verify until the next real release, since this fix needs one manual hard-refresh of the \`argocd\` app itself to take effect -- ironic bootstrapping problem)

🤖 Generated with [Claude Code](https://claude.com/claude-code)