### PR TITLE
fix: run scheduled email campaigns

### DIFF
--- a/pickem/pickem_api/scheduler.py
+++ b/pickem/pickem_api/scheduler.py
@@ -78,7 +78,7 @@ def _run_command_step(job_id):
     call_command_logged(job_id, logger_name=f'django.job.{job_id}')
 
 
-def _run_email_campaigns(job_id):
+def _run_email_campaigns():
     from pickem_homepage.emailing import send_due_email_campaigns
 
     send_due_email_campaigns()

--- a/pickem/pickem_superadmin/tests/test_scheduling.py
+++ b/pickem/pickem_superadmin/tests/test_scheduling.py
@@ -86,6 +86,21 @@ class RunJobOnceTests(TestCase):
         self.assertEqual(job_id, 'update_stats')
         self.assertEqual(scheduler.current_log_context(), (None, None))
 
+    @patch('pickem_homepage.emailing.send_due_email_campaigns')
+    def test_scheduled_email_campaign_runner_needs_no_job_argument(self, send_campaigns):
+        from pickem_api import scheduler
+
+        scheduler.run_job_once(
+            'send_scheduled_email_campaigns',
+            run=scheduler._RUN_BY_ID['send_scheduled_email_campaigns'],
+        )
+
+        send_campaigns.assert_called_once_with()
+        self.assertEqual(
+            JobRun.objects.get(job_id='send_scheduled_email_campaigns').status,
+            JobRun.Status.SUCCESS,
+        )
+
 
 class PipelineTickTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- correct the scheduled email campaign callable signature
- add regression coverage through the scheduler execution path

## Validation
- `python manage.py test pickem_superadmin.tests.test_scheduling.RunJobOnceTests --keepdb -v 1`
- `python manage.py check`

Fixes the TypeError reported by Sentry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduled email campaign execution to run reliably through the scheduler.
  * Confirmed successful job completion and email delivery during scheduled runs.

* **Tests**
  * Added coverage verifying scheduled email campaigns execute without unexpected arguments and complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->