### PR TITLE
feat: emit Sentry scheduler metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ User → userStats (One-to-One)
 | `SECRET_KEY` | Django secret key | Yes |
 | `DATABASE_URL` | PostgreSQL connection string | Yes |
 | `DATABASE_CONN_MAX_AGE` | Seconds to reuse a database connection before reconnecting (defaults to `60`) | No |
+| `SENTRY_TRACES_SAMPLE_RATE` | Fraction of transactions sent to Sentry traces (defaults to `0.1`) | No |
+| `SENTRY_PROFILE_SESSION_SAMPLE_RATE` | Fraction of sampled trace sessions profiled by Sentry (defaults to `0.1`) | No |
 | `GOOGLE_OAUTH2_KEY` | Google OAuth client ID | Yes |
 | `GOOGLE_OAUTH2_SECRET` | Google OAuth client secret | Yes |
 | `DEBUG` | Enable debug mode | No |

--- a/pickem/pickem/settings.py
+++ b/pickem/pickem/settings.py
@@ -28,7 +28,7 @@ ACCOUNT_DEFAULT_HTTP_PROTOCOL='https'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.getenv('DEBUG', 'False').lower() == 'true'
 
-# --- Sentry error tracking & performance tracing ---------------------------
+# --- Sentry error tracking, performance tracing & metrics ------------------
 # Disabled unless SENTRY_DSN is set, so local dev/tests never enable it. The
 # DSN comes from AWS Secrets Manager -> ESO -> K8s Secret, same as every
 # other deployment secret in this app -- never hardcode it here.
@@ -42,6 +42,14 @@ if SENTRY_DSN:
         # default -- flip this on only if that visibility is deliberately wanted.
         send_default_pii=False,
         traces_sample_rate=float(os.environ.get('SENTRY_TRACES_SAMPLE_RATE', '0.1')),
+        # Metrics are enabled by default in sentry-sdk >= 2.44. Application
+        # code emits bounded scheduler run/duration measurements.
+        # Profile only sampled traces by default. The independent rate keeps
+        # profiling overhead controllable without changing application code.
+        profile_session_sample_rate=float(
+            os.environ.get('SENTRY_PROFILE_SESSION_SAMPLE_RATE', '0.1')
+        ),
+        profile_lifecycle='trace',
         # Tags events with the deployed chart/image version (APP_RELEASE is
         # set in the Helm chart's deployment template) so an error spike can
         # be traced back to the release that introduced it.

--- a/pickem/pickem_api/scheduler.py
+++ b/pickem/pickem_api/scheduler.py
@@ -22,6 +22,7 @@ from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.interval import IntervalTrigger
 from django.conf import settings
 from django.core.management import call_command
+from sentry_sdk import metrics
 
 logger = logging.getLogger(__name__)
 
@@ -70,6 +71,18 @@ _current_job_id = contextvars.ContextVar('pickem_job_id', default=None)
 def current_log_context():
     """(run_id, job_id) for the job running in this context, or (None, None)."""
     return _current_run_id.get(), _current_job_id.get()
+
+
+def _record_job_metrics(job_id, status, duration_ms):
+    """Emit bounded scheduler metrics without risking the job itself."""
+    attributes = {'job_id': job_id, 'status': status}
+    try:
+        metrics.count('scheduler.job_runs', 1, attributes=attributes)
+        metrics.distribution('scheduler.job_duration_ms', duration_ms, attributes=attributes)
+    except Exception:
+        # Sentry metrics are observability-only. A telemetry outage must never
+        # make a scheduled scoring or email job look like it failed.
+        logger.debug('Unable to emit scheduler metrics', exc_info=True)
 
 
 def _run_command_step(job_id):
@@ -149,12 +162,14 @@ def run_job_once(job_id, run=None):
         logging.getLogger(f'django.job.{job_id}').exception('Job %s failed', job_id)
     finally:
         finished = timezone.now()
+        duration_ms = int((finished - job_run.started_at).total_seconds() * 1000)
         JobRun.objects.filter(pk=job_run.pk).update(
             finished_at=finished,
             status=status,
-            duration_ms=int((finished - job_run.started_at).total_seconds() * 1000),
+            duration_ms=duration_ms,
             exception=exc_text,
         )
+        _record_job_metrics(job_id, status, duration_ms)
         ScheduledJobConfig.objects.filter(job_id=job_id).update(last_run_at=finished)
         mark_job_finished(job_id)
         _current_job_id.reset(token_job)

--- a/pickem/pickem_superadmin/tests/test_scheduling.py
+++ b/pickem/pickem_superadmin/tests/test_scheduling.py
@@ -86,6 +86,19 @@ class RunJobOnceTests(TestCase):
         self.assertEqual(job_id, 'update_stats')
         self.assertEqual(scheduler.current_log_context(), (None, None))
 
+    @patch('pickem_api.scheduler.metrics')
+    def test_emits_bounded_sentry_metrics_for_job_runs(self, sentry_metrics):
+        from pickem_api import scheduler
+
+        scheduler.run_job_once('update_picks', run=lambda: None)
+
+        attributes = {'job_id': 'update_picks', 'status': JobRun.Status.SUCCESS}
+        sentry_metrics.count.assert_called_once_with('scheduler.job_runs', 1, attributes=attributes)
+        metric_name, duration_ms = sentry_metrics.distribution.call_args.args
+        self.assertEqual(metric_name, 'scheduler.job_duration_ms')
+        self.assertGreaterEqual(duration_ms, 0)
+        self.assertEqual(sentry_metrics.distribution.call_args.kwargs['attributes'], attributes)
+
     @patch('pickem_homepage.emailing.send_due_email_campaigns')
     def test_scheduled_email_campaign_runner_needs_no_job_argument(self, send_campaigns):
         from pickem_api import scheduler


### PR DESCRIPTION
## Summary
- emit a `scheduler.job_runs` count for each scheduled job outcome
- emit a `scheduler.job_duration_ms` distribution for each run
- use only bounded `job_id` and `status` attributes
- keep telemetry failures non-fatal

## Validation
- `python manage.py test pickem_superadmin.tests.test_scheduling.RunJobOnceTests --keepdb -v 1`
- `python manage.py check`