### PR TITLE
Hide raw invite link fallback once Resend is configured

### DIFF
--- a/pickem/pickem_homepage/tests.py
+++ b/pickem/pickem_homepage/tests.py
@@ -5010,7 +5010,8 @@ class FamilyAdminExperienceTests(TestCase):
         self.assertNotContains(response, "OTHER-FAMILY-CODE")
         self.assertNotContains(response, "Jones Family")
 
-    def test_admin_and_owner_can_create_member_invites_with_one_time_link_display(self):
+    @patch("pickem_homepage.views.resend_invite_email_is_configured", return_value=False)
+    def test_admin_and_owner_can_create_member_invites_with_one_time_link_display(self, configured_mock):
         for user in (self.owner, self.admin_user):
             with self.subTest(user=user.username):
                 self.client.force_login(user)
@@ -5079,6 +5080,9 @@ class FamilyAdminExperienceTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Invite email will be sent to target@example.com.")
+        self.assertContains(response, "Invite created.")
+        self.assertNotContains(response, "Share the invite link now")
+        self.assertIsNone(response.context.get("invite_link"))
         configured_mock.assert_called_once_with()
         on_commit_mock.assert_called_once()
         send_mock.assert_called_once_with(
@@ -5110,6 +5114,7 @@ class FamilyAdminExperienceTests(TestCase):
             response,
             "Invite saved for target@example.com, but Resend is not configured yet so no email was sent. Use the invite link below.",
         )
+        self.assertIsNotNone(response.context.get("invite_link"))
         configured_mock.assert_called_once_with()
         send_mock.assert_not_called()
 
@@ -5128,8 +5133,10 @@ class FamilyAdminExperienceTests(TestCase):
         response = self.client.post(self._invite_replace_url(invite))
 
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "Invite replaced. Share the new invite link now.")
+        self.assertContains(response, "Invite replaced.")
+        self.assertNotContains(response, "Share the new invite link now.")
         self.assertContains(response, "Invite email will be sent to target@example.com.")
+        self.assertIsNone(response.context.get("invite_link"))
         configured_mock.assert_called_once_with()
         on_commit_mock.assert_called_once()
         send_mock.assert_called_once_with(
@@ -5155,6 +5162,7 @@ class FamilyAdminExperienceTests(TestCase):
             response,
             "Invite saved for target@example.com, but Resend is not configured yet so no email was sent. Use the invite link below.",
         )
+        self.assertIsNotNone(response.context.get("invite_link"))
         configured_mock.assert_called_once_with()
         send_mock.assert_not_called()
 
@@ -5955,6 +5963,35 @@ class BatchInviteTests(TestCase):
         self.assertIn("b@x.com", recipient_emails)
         self.assertContains(response, "Sent 2 invite(s).")
         # A multi-invite batch does not surface a one-time invite link.
+        self.assertIsNone(response.context.get("invite_link"))
+
+    @patch("pickem_homepage.views.transaction.on_commit", side_effect=lambda callback: callback())
+    @patch("pickem_homepage.views.send_family_invitation_email")
+    @patch("pickem_homepage.views.resend_invite_email_is_configured", return_value=True)
+    def test_multiple_emails_with_resend_configured_queues_each_delivery_once(
+        self,
+        configured_mock,
+        send_mock,
+        on_commit_mock,
+    ):
+        # resend_invite_email_is_configured() is hoisted out of the per-invite
+        # loop and reused, so it must be called exactly once per request even
+        # though two invites are created here - not once per invite.
+        response = self.client.post(
+            self._invites_url(),
+            {
+                "role": FamilyMembership.Role.MEMBER,
+                "recipient_email": ["a@x.com", "b@x.com"],
+                "expires_in_days": "14",
+            },
+            follow=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        configured_mock.assert_called_once_with()
+        self.assertEqual(send_mock.call_count, 2)
+        self.assertContains(response, "Invite email will be sent to a@x.com.")
+        self.assertContains(response, "Invite email will be sent to b@x.com.")
         self.assertIsNone(response.context.get("invite_link"))
 
     def test_invalid_email_skipped_valid_still_created(self):

--- a/pickem/pickem_homepage/views.py
+++ b/pickem/pickem_homepage/views.py
@@ -2361,11 +2361,14 @@ def build_invite_audit_metadata(invitation, *, source, replacement_for=None):
     return metadata
 
 
-def handle_targeted_invite_email_feedback(request, *, invitation, raw_code):
+def handle_targeted_invite_email_feedback(request, *, invitation, raw_code, email_configured):
+    """Emits the create/replace feedback message and returns the raw invite
+    link, or None when Resend is configured (the link is only a fallback for
+    when it isn't - see GH #89)."""
     invite_link = request.build_absolute_uri(
         reverse('accept_invite_link', kwargs={'invite_code': raw_code})
     )
-    if resend_invite_email_is_configured():
+    if email_configured:
         transaction.on_commit(
             lambda: send_family_invitation_email(
                 invitation=invitation,
@@ -2377,14 +2380,15 @@ def handle_targeted_invite_email_feedback(request, *, invitation, raw_code):
             request,
             f"Invite email will be sent to {invitation.recipient_email}.",
         )
-    else:
-        messages.warning(
-            request,
-            (
-                f"Invite saved for {invitation.recipient_email}, but Resend is not "
-                "configured yet so no email was sent. Use the invite link below."
-            ),
-        )
+        return None
+    messages.warning(
+        request,
+        (
+            f"Invite saved for {invitation.recipient_email}, but Resend is not "
+            "configured yet so no email was sent. Use the invite link below."
+        ),
+    )
+    return invite_link
 
 
 def create_admin_invitation(
@@ -2520,13 +2524,6 @@ def family_pool_admin_invites(request, family_slug, pool_slug):
                 )
                 created.append((invitation, raw_code))
 
-        for invitation, raw_code in created:
-            handle_targeted_invite_email_feedback(
-                request,
-                invitation=invitation,
-                raw_code=raw_code,
-            )
-
         if not created:
             messages.error(
                 request,
@@ -2537,16 +2534,29 @@ def family_pool_admin_invites(request, family_slug, pool_slug):
             )
             return render_family_admin_invites(request, tenant_context, form, status=400)
 
+        email_configured = resend_invite_email_is_configured()
+        invite_links = {
+            raw_code: handle_targeted_invite_email_feedback(
+                request,
+                invitation=invitation,
+                raw_code=raw_code,
+                email_configured=email_configured,
+            )
+            for invitation, raw_code in created
+        }
+
         if len(created) == 1 and not skipped_invalid:
             _invitation, raw_code = created[0]
-            messages.success(request, "Invite created. Share the invite link now; it will not be shown again.")
+            invite_link = invite_links[raw_code]
+            if invite_link:
+                messages.success(request, "Invite created. Share the invite link now; it will not be shown again.")
+            else:
+                messages.success(request, "Invite created.")
             return render_family_admin_invites(
                 request,
                 tenant_context,
                 form,
-                invite_link=request.build_absolute_uri(
-                    reverse('accept_invite_link', kwargs={'invite_code': raw_code})
-                ),
+                invite_link=invite_link,
             )
 
         summary = f"Sent {len(created)} invite(s)."
@@ -2652,19 +2662,21 @@ def family_pool_admin_invite_replace(request, family_slug, pool_slug, invitation
             'expires_in_days': 14,
         },
     )
-    handle_targeted_invite_email_feedback(
+    invite_link = handle_targeted_invite_email_feedback(
         request,
         invitation=new_invitation,
         raw_code=raw_code,
+        email_configured=resend_invite_email_is_configured(),
     )
-    messages.success(request, "Invite replaced. Share the new invite link now.")
+    if invite_link:
+        messages.success(request, "Invite replaced. Share the new invite link now.")
+    else:
+        messages.success(request, "Invite replaced.")
     return render_family_admin_invites(
         request,
         tenant_context,
         form,
-        invite_link=request.build_absolute_uri(
-            reverse('accept_invite_link', kwargs={'invite_code': raw_code})
-        ),
+        invite_link=invite_link,
     )
 
 


### PR DESCRIPTION
## Summary
- The family admin invites page (create + replace) always displayed the one-time invite link, even when the invite email was actually sent via Resend.
- Now the raw link is only surfaced as a fallback when Resend isn't configured (`resend_invite_email_is_configured()` returns `False`), matching the existing warning/success messaging that already branched on that check.
- Centralized the link-building/gating logic into `handle_targeted_invite_email_feedback` (now returns the link or `None`) so both call sites (single-invite create, replace) share one source of truth instead of duplicating the decision.
- Aligned success messaging so create and replace always show a base confirmation ("Invite created."/"Invite replaced.") regardless of Resend config, with the link + "share it" wording only added when it's actually shown.

Closes #89

## Test plan
- [x] `python manage.py test --settings=pickem.test_settings` — 843 tests pass
- [x] Added/updated invite tests covering: link hidden when configured (create + replace), link still shown as fallback when not configured, batch invites reuse a single config check instead of one per recipient