### PR TITLE
fix: keep public footer visible

### DIFF
--- a/pickem/pickem_homepage/templates/pickem/home.html
+++ b/pickem/pickem_homepage/templates/pickem/home.html
@@ -307,21 +307,6 @@
         yoyo: true
     });
 
-    if (window.ScrollTrigger) {
-        document.querySelectorAll('.landing-section, .family-proof-row').forEach(function (section) {
-            gsap.from(section, {
-                autoAlpha: 0,
-                y: 34,
-                duration: 0.7,
-                ease: 'power2.out',
-                scrollTrigger: {
-                    trigger: section,
-                    start: 'top 86%',
-                    once: true
-                }
-            });
-        });
-    }
 })();
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- remove the generic GSAP section animation that could leave the footer hidden
- retain targeted hero motion and card hover interactions

## Validation
- `python manage.py check`