### PR TITLE
fix: gate ArgoCD prd update on Docker push succeeding

### DIFF
--- a/.github/workflows/publish-artifacts.yaml
+++ b/.github/workflows/publish-artifacts.yaml
@@ -146,7 +146,12 @@ jobs:
 
   update_argocd:
     name: Update ArgoCD production app version
-    needs: [publish_helm]
+    # Must wait on publish_docker too, not just publish_helm: if the Docker
+    # push fails (e.g. a transient registry timeout) while the Helm publish
+    # succeeds, this job would otherwise still bump prd's targetRevision to
+    # a version whose image doesn't exist yet, and ArgoCD would pull it
+    # immediately (production incident 2026-07-25, family-pickem-0.0.190).
+    needs: [publish_docker, publish_helm]
     permissions:
       contents: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
`update_argocd` only depended on `publish_helm`, so a Docker Hub push failure didn't block it from bumping prd's `targetRevision`. This bit us on the `family-pickem-0.0.190` release (2026-07-25): a transient Docker Hub timeout failed the image push, but the ArgoCD job ran anyway and prd synced to a version whose image didn't exist — a pod got stuck in `ImagePullBackOff` until the push was retried. The old pod was still serving traffic throughout, so no user-facing outage, but the workflow should have prevented this rather than requiring a manual catch.

## Fix
`update_argocd` now depends on both `publish_docker` and `publish_helm`.

## Test plan
- [x] Validated the job graph (`needs` references resolve, no cycles)
- N/A for a live workflow-behavior test — this only changes job ordering; will be implicitly exercised on the next release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow coordination so production updates occur only after all required application artifacts are successfully published.
  * This helps keep production deployments consistent and reduces the risk of updating applications before their corresponding release artifacts are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->