### PR TITLE
Live updates Phase 1: shared Redis cache backend (#93)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,6 +275,7 @@ Key packages:
 - **psycopg2-binary** - PostgreSQL driver
 - **espn-api** - NFL data integration
 - **boto3/django-storages** - AWS S3 for static files (production)
+- **django-redis** - Shared Redis cache backend (used when `REDIS_URL` is set; falls back to file-based cache locally)
 - **Tailwind CSS** - Modern CSS framework (in migration)
 
 Rate limiting is handled at the Cloudflare edge, not in the Django app

--- a/charts/family-pickem/templates/deployment.yaml
+++ b/charts/family-pickem/templates/deployment.yaml
@@ -68,6 +68,12 @@ spec:
                 fieldPath: status.podIP
           - name: APP_RELEASE
             value: "{{ .Values.image.tag | default .Chart.AppVersion }}"
+          {{- if .Values.redis.enabled }}
+          # Shared Redis cache/broker (self-managed; see templates/redis.yaml).
+          # DB 1 is the Django cache; later phases use other DB indexes for pub/sub.
+          - name: REDIS_URL
+            value: "redis://{{ include "family-pickem.fullname" . }}-redis:6379/1"
+          {{- end }}
           {{- if and .Values.scheduler.enabled .Values.autoscaling.enabled }}
           {{ fail "scheduler.enabled requires autoscaling.enabled=false" }}
           {{- end }}

--- a/charts/family-pickem/templates/redis.yaml
+++ b/charts/family-pickem/templates/redis.yaml
@@ -26,8 +26,19 @@ spec:
         - name: redis
           image: {{ .Values.redis.image | quote }}
           imagePullPolicy: IfNotPresent
-          # Ephemeral cache/broker: disable RDB snapshots and AOF entirely.
-          args: ["--save", "", "--appendonly", "no"]
+          # Ephemeral cache/broker: disable RDB snapshots and AOF, and bound the
+          # dataset with LRU eviction so Redis can never grow past its container
+          # limit and OOM the node. (allkeys-lru is safe here: DB 1 is a pure
+          # cache and pub/sub messages don't live in the keyspace.)
+          args:
+            - "--save"
+            - ""
+            - "--appendonly"
+            - "no"
+            - "--maxmemory"
+            - {{ .Values.redis.maxmemory | quote }}
+            - "--maxmemory-policy"
+            - {{ .Values.redis.maxmemoryPolicy | quote }}
           ports:
             - name: redis
               containerPort: 6379

--- a/charts/family-pickem/templates/redis.yaml
+++ b/charts/family-pickem/templates/redis.yaml
@@ -1,0 +1,63 @@
+{{- if .Values.redis.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "family-pickem.fullname" . }}-redis
+  labels:
+    {{- include "family-pickem.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  replicas: 1
+  # Recreate: a single ephemeral cache instance; never run two at once.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "family-pickem.name" . }}-redis
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "family-pickem.name" . }}-redis
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: redis
+    spec:
+      containers:
+        - name: redis
+          image: {{ .Values.redis.image | quote }}
+          imagePullPolicy: IfNotPresent
+          # Ephemeral cache/broker: disable RDB snapshots and AOF entirely.
+          args: ["--save", "", "--appendonly", "no"]
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: redis
+            initialDelaySeconds: 10
+          readinessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 5
+          resources:
+            {{- toYaml .Values.redis.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "family-pickem.fullname" . }}-redis
+  labels:
+    {{- include "family-pickem.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  type: ClusterIP
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: redis
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: {{ include "family-pickem.name" . }}-redis
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/family-pickem/values.yaml
+++ b/charts/family-pickem/values.yaml
@@ -77,6 +77,17 @@ postgresql:
         # password: ""
         database: "pickem"
 
+# Shared Redis: the Django cache now, and the pub/sub broker for live updates
+# later (#93). Self-managed (NOT the Bitnami subchart — Bitnami deprecated its
+# free catalog in Aug 2025). Disabled by default; enabled per environment in
+# infra/app/. Ephemeral: no persistence, since it is only a cache/broker.
+# Reachable only inside the cluster network, so it runs without auth; add auth
+# (a password from AWS Secrets Manager via ESO) before ever exposing it.
+redis:
+  enabled: false
+  image: "redis:7.4-alpine"
+  resources: {}
+
 # In-process update scheduler (django-apscheduler). When enabled, sets
 # RUN_SCHEDULER=true on the single web replica so it runs the update_all
 # pipeline internally; the legacy cron CronJob below should be suspended.

--- a/charts/family-pickem/values.yaml
+++ b/charts/family-pickem/values.yaml
@@ -86,7 +86,17 @@ postgresql:
 redis:
   enabled: false
   image: "redis:7.4-alpine"
-  resources: {}
+  # Bound the dataset (maxmemory) below the container limit and evict LRU keys
+  # so Redis can never OOM the node. Keep maxmemory well under resources.limits
+  # memory to leave headroom for the Redis process + fragmentation.
+  maxmemory: "180mb"
+  maxmemoryPolicy: "allkeys-lru"
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      memory: 256Mi
 
 # In-process update scheduler (django-apscheduler). When enabled, sets
 # RUN_SCHEDULER=true on the single web replica so it runs the update_all

--- a/docs/superpowers/plans/2026-08-02-live-updates-phase1-redis.md
+++ b/docs/superpowers/plans/2026-08-02-live-updates-phase1-redis.md
@@ -1,0 +1,445 @@
+# Live Updates — Phase 1: Redis Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stand up a shared Redis instance and repoint Django's default cache at it, so the app has a cross-request/cross-replica cache and a broker that later phases use for live-update pub/sub.
+
+**Architecture:** Add a Bitnami Redis subchart to the Helm chart (opt-in per environment). The Django app selects its cache backend at startup: Redis when `REDIS_URL` is set, otherwise the existing file-based cache — so local dev and the test suite need no external services. The `REDIS_URL` is derived in the deployment template from the Helm release name, matching Bitnami's `{release}-redis-master` service.
+
+**Tech Stack:** Django 5.2, django-redis, Bitnami Redis Helm subchart, Helm, ArgoCD GitOps, uv.
+
+## Global Constraints
+
+- Python `>=3.12`; Django `5.2.16`. (`pyproject.toml`)
+- All Python deps are pinned to exact versions in `pyproject.toml` and locked in `uv.lock`; add deps with `uv add <pkg>==<version>` (never hand-edit the lock). (`pyproject.toml`)
+- Tests run against SQLite via `--settings=pickem.test_settings` from the `pickem/` directory. (`pickem/pickem/test_settings.py`)
+- Bitnami subchart resources are named `{release}-<subchart>` where release = `pickem-prd` / `pickem-dev` (NOT `fullnameOverride`). The Redis primary service is therefore `pickem-prd-redis-master` / `pickem-dev-redis-master`. (memory: Bitnami subchart naming; `infra/argocd/applications/pickem-prd.yaml`)
+- Do NOT hardcode ArgoCD chart `targetRevision` values; the release workflow manages them. Pinning a *subchart dependency version* inside `charts/family-pickem/Chart.yaml` is fine and expected.
+- Never edit K8s Secrets directly; secrets flow AWS Secrets Manager → ESO → K8s. (This phase needs NO new secret — see Task 2 note on auth.)
+- GitOps: dev tracks `main` automatically; prd tracks GitHub Releases. Enabling Redis in an environment happens by merging a values change, not by `kubectl` edits.
+
+---
+
+### Task 1: Cache backend selection (app-side)
+
+Add `django-redis`, extract cache-backend selection into a testable helper, and wire it into settings so Redis is used when `REDIS_URL` is present and the file-based cache otherwise.
+
+**Files:**
+- Create: `pickem/pickem/cache.py`
+- Create: `pickem/pickem_api/tests/test_cache_config.py`
+- Modify: `pickem/pickem/settings.py:137-146` (replace the inline `CACHES` dict)
+- Modify: `pyproject.toml` (add `django-redis` via `uv add`)
+
+**Interfaces:**
+- Produces: `pickem.cache.build_caches(environ)` → `dict` — a Django `CACHES` mapping. `environ` is any mapping (typically `os.environ`). Returns the Redis backend when `environ['REDIS_URL']` is a non-blank string, else the file-based backend.
+
+- [ ] **Step 1: Add the django-redis dependency**
+
+Run from repo root:
+
+```bash
+uv add "django-redis==5.4.0"
+```
+
+This updates `pyproject.toml` and `uv.lock` (pulls in `redis` as a transitive dep). Confirm `pyproject.toml` now lists `django-redis==5.4.0`.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `pickem/pickem_api/tests/test_cache_config.py`:
+
+```python
+from pickem.cache import build_caches
+
+
+def test_uses_filebased_cache_when_no_redis_url():
+    caches = build_caches({})
+    assert caches['default']['BACKEND'] == (
+        'django.core.cache.backends.filebased.FileBasedCache'
+    )
+
+
+def test_uses_redis_when_redis_url_set():
+    caches = build_caches({'REDIS_URL': 'redis://example:6379/1'})
+    default = caches['default']
+    assert default['BACKEND'] == 'django_redis.cache.RedisCache'
+    assert default['LOCATION'] == 'redis://example:6379/1'
+    # A cache outage must degrade to "no cache", never surface as a 500.
+    assert default['OPTIONS']['IGNORE_EXCEPTIONS'] is True
+
+
+def test_blank_redis_url_falls_back_to_filebased():
+    caches = build_caches({'REDIS_URL': '   '})
+    assert caches['default']['BACKEND'] == (
+        'django.core.cache.backends.filebased.FileBasedCache'
+    )
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run:
+
+```bash
+cd pickem && uv run python manage.py test pickem_api.tests.test_cache_config --settings=pickem.test_settings -v 2
+```
+
+Expected: FAIL — `ModuleNotFoundError: No module named 'pickem.cache'`.
+
+- [ ] **Step 4: Write the minimal implementation**
+
+Create `pickem/pickem/cache.py`:
+
+```python
+"""Cache backend selection.
+
+Uses Redis (shared across requests and replicas) when ``REDIS_URL`` is set,
+otherwise falls back to the local file-based cache so local development and the
+test suite need no external services.
+
+See docs/superpowers/specs/2026-08-02-live-updates-design.md (Phase 1) and
+issue #93.
+"""
+
+
+def build_caches(environ):
+    """Return a Django ``CACHES`` dict based on the given environment mapping.
+
+    ``environ`` is typically ``os.environ``. When ``REDIS_URL`` is a non-blank
+    string the default cache is Redis (via django-redis); otherwise it is the
+    file-based cache at ``/tmp/django_cache``.
+    """
+    redis_url = environ.get('REDIS_URL', '').strip()
+    if redis_url:
+        return {
+            'default': {
+                'BACKEND': 'django_redis.cache.RedisCache',
+                'LOCATION': redis_url,
+                'TIMEOUT': 300,  # 5 minutes
+                'OPTIONS': {
+                    'CLIENT_CLASS': 'django_redis.client.DefaultClient',
+                    # A cache outage must degrade to "no cache", never 500s.
+                    'IGNORE_EXCEPTIONS': True,
+                },
+            }
+        }
+    return {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
+            'LOCATION': '/tmp/django_cache',
+            'TIMEOUT': 300,  # 5 minutes
+            'OPTIONS': {
+                'MAX_ENTRIES': 1000,
+            },
+        }
+    }
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run:
+
+```bash
+cd pickem && uv run python manage.py test pickem_api.tests.test_cache_config --settings=pickem.test_settings -v 2
+```
+
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Wire the helper into settings**
+
+In `pickem/pickem/settings.py`, replace the inline `CACHES` block (currently lines 137-146):
+
+```python
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
+        'LOCATION': '/tmp/django_cache',
+        'TIMEOUT': 300,  # 5 minutes
+        'OPTIONS': {
+            'MAX_ENTRIES': 1000,
+        }
+    }
+}
+```
+
+with:
+
+```python
+from .cache import build_caches
+
+# Redis when REDIS_URL is set (see pickem/cache.py and issue #93); the
+# file-based cache otherwise, so local dev and tests need no external services.
+CACHES = build_caches(os.environ)
+```
+
+- [ ] **Step 7: Verify the full suite still passes with the file-based fallback**
+
+Run (no `REDIS_URL` in the environment, so the fallback branch is exercised):
+
+```bash
+cd pickem && uv run python manage.py test --settings=pickem.test_settings
+```
+
+Expected: the suite passes as before (no new failures introduced).
+
+- [ ] **Step 8: Update the dependency note in CLAUDE.md**
+
+In `CLAUDE.md`, under "Dependencies" / "Key packages", add a line:
+
+```markdown
+- **django-redis** - Shared Redis cache backend (used when `REDIS_URL` is set; falls back to file-based cache locally)
+```
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add pyproject.toml uv.lock pickem/pickem/cache.py pickem/pickem_api/tests/test_cache_config.py pickem/pickem/settings.py CLAUDE.md
+git commit -m "feat(cache): select Redis backend when REDIS_URL is set
+
+Extract cache-backend selection into pickem.cache.build_caches so it is
+unit-testable; use django-redis when REDIS_URL is present, else keep the
+file-based cache for local dev and tests. Foundation for live updates (#93).
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Redis subchart + chart wiring (chart-side)
+
+Add the Bitnami Redis subchart to the Helm chart, default it off, and inject `REDIS_URL` into the web deployment when it is enabled.
+
+**Files:**
+- Modify: `charts/family-pickem/Chart.yaml` (add `redis` dependency)
+- Modify: `charts/family-pickem/values.yaml` (add `redis:` block, default disabled)
+- Modify: `charts/family-pickem/templates/deployment.yaml` (add `REDIS_URL` env in the main container)
+
+**Interfaces:**
+- Produces: when `redis.enabled=true`, the web container gets env `REDIS_URL=redis://{{ .Release.Name }}-redis-master:6379/1`, consumed by `pickem.cache.build_caches` from Task 1.
+
+- [ ] **Step 1: Add the Redis dependency to Chart.yaml**
+
+In `charts/family-pickem/Chart.yaml`, add to the `dependencies:` list (below the existing `postgresql` entry):
+
+```yaml
+  - name: "redis"
+    version: 17.11.3
+    repository: "https://charts.bitnami.com/bitnami"
+    condition: redis.enabled
+```
+
+- [ ] **Step 2: Add the redis values block**
+
+In `charts/family-pickem/values.yaml`, add after the `postgresql:` block:
+
+```yaml
+# Shared Redis: the Django cache now, and the pub/sub broker for live updates
+# later (#93). Disabled by default; enabled per environment in infra/app/.
+#
+# auth.enabled=false — Redis is only reachable inside the cluster network on
+# this private single-node cluster. Enable auth.enabled + an existingSecret
+# (sourced from AWS Secrets Manager) before ever exposing it beyond the cluster.
+#
+# persistence disabled — the cache is ephemeral; nothing here must survive a
+# restart. Bitnami names the primary service {release}-redis-master.
+redis:
+  enabled: false
+  architecture: standalone
+  auth:
+    enabled: false
+  master:
+    persistence:
+      enabled: false
+```
+
+- [ ] **Step 3: Inject REDIS_URL into the deployment**
+
+In `charts/family-pickem/templates/deployment.yaml`, in the **main app container** (`containers:` → `name: {{ .Chart.Name }}`), add the following immediately after the `APP_RELEASE` env entry (which sits just before the `scheduler.enabled` block):
+
+```yaml
+          {{- if .Values.redis.enabled }}
+          # Shared Redis cache/broker. Host follows Bitnami's
+          # {release}-redis-master service; DB 1 is the Django cache, later
+          # phases use other DB indexes for pub/sub.
+          - name: REDIS_URL
+            value: "redis://{{ .Release.Name }}-redis-master:6379/1"
+          {{- end }}
+```
+
+- [ ] **Step 4: Fetch the subchart and lint**
+
+Run:
+
+```bash
+helm repo add bitnami https://charts.bitnami.com/bitnami
+cd charts/family-pickem && helm dependency build
+helm lint . -f ../../infra/app/values-prd.yaml --set redis.enabled=true
+```
+
+Expected: `helm dependency build` downloads `redis-17.11.3.tgz` into `charts/family-pickem/charts/`; `helm lint` reports `0 chart(s) failed`.
+
+- [ ] **Step 5: Verify the rendered REDIS_URL and subchart**
+
+Run:
+
+```bash
+cd charts/family-pickem
+helm template pickem-prd . -f ../../infra/app/values-prd.yaml --set redis.enabled=true | grep -A2 "name: REDIS_URL"
+helm template pickem-prd . -f ../../infra/app/values-prd.yaml --set redis.enabled=true | grep "kind: StatefulSet"
+```
+
+Expected:
+- The first command prints `value: "redis://pickem-prd-redis-master:6379/1"`.
+- The second shows the Bitnami Redis `StatefulSet` is rendered.
+
+Also confirm the default is still off:
+
+```bash
+helm template pickem-prd . -f ../../infra/app/values-prd.yaml | grep "REDIS_URL" || echo "REDIS_URL absent by default — correct"
+```
+
+Expected: prints `REDIS_URL absent by default — correct`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add charts/family-pickem/Chart.yaml charts/family-pickem/Chart.lock charts/family-pickem/values.yaml charts/family-pickem/templates/deployment.yaml
+git commit -m "feat(chart): add optional Redis subchart and REDIS_URL wiring
+
+Bitnami Redis subchart gated on redis.enabled (default off). When enabled,
+the web deployment gets REDIS_URL pointing at the {release}-redis-master
+service. No new secret: in-cluster Redis runs with auth disabled. (#93)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+> Note: `helm dependency build` may also create/update `charts/family-pickem/Chart.lock`. Do **not** commit the downloaded `charts/*.tgz` if a `.helmignore`/`.gitignore` already excludes them; check `git status` and add only `Chart.lock` if the tgz is ignored. If the tgz is normally committed in this repo, add it too.
+
+---
+
+### Task 3: Enable Redis in the dev environment
+
+Turn Redis on for dev, let ArgoCD sync it, and verify the app actually uses it.
+
+**Files:**
+- Modify: `infra/app/values-dev.yaml` (set `redis.enabled: true`)
+
+- [ ] **Step 1: Enable redis in dev values**
+
+In `infra/app/values-dev.yaml`, add a top-level block (near the `postgresql:` block):
+
+```yaml
+redis:
+  enabled: true
+```
+
+- [ ] **Step 2: Confirm the dev render**
+
+Run:
+
+```bash
+cd charts/family-pickem
+helm template pickem-dev . -f ../../infra/app/values-dev.yaml | grep -A2 "name: REDIS_URL"
+```
+
+Expected: `value: "redis://pickem-dev-redis-master:6379/1"`.
+
+- [ ] **Step 3: Commit and push (dev auto-deploys from main)**
+
+```bash
+git add infra/app/values-dev.yaml
+git commit -m "feat(dev): enable Redis in the dev environment (#93)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+This change deploys to dev once merged to `main` (ArgoCD `pickem-dev` tracks main).
+
+- [ ] **Step 4: Verify in the running dev cluster (post-merge)**
+
+After ArgoCD syncs dev, confirm Redis is up and the app is using it:
+
+```bash
+# Redis pod running
+kubectl get pods -n pickem-dev | grep redis
+# App is pointed at Redis and can round-trip the cache
+kubectl exec -n pickem-dev deploy/family-pickem-dev -- \
+  python pickem/manage.py shell -c \
+  "from django.core.cache import cache; cache.set('livecheck','ok',30); print('CACHE:', cache.get('livecheck'))"
+# The key is visible in Redis DB 1
+kubectl exec -n pickem-dev statefulset/pickem-dev-redis-master -- \
+  redis-cli -n 1 keys '*livecheck*'
+```
+
+Expected: the Redis pod is `Running`; the shell prints `CACHE: ok`; `redis-cli` lists a `...livecheck` key.
+
+> **Risk to watch here (most likely failure point):** a 2-year-old Bitnami image tag may no longer be pullable after Bitnami's 2025 registry changes. If the Redis pod is `ImagePullBackOff`, override the image in `values.yaml`'s `redis:` block to the still-published location — e.g. set `redis.image.registry: docker.io` and `redis.image.repository: bitnamilegacy/redis` — or bump the subchart to a newer version whose images are published, then re-run Task 2 Steps 4-5. Resolve this in dev before Task 4.
+
+---
+
+### Task 4: Enable Redis in the production environment
+
+Only after dev is verified. This is the production rollout gate.
+
+**Files:**
+- Modify: `infra/app/values-prd.yaml` (set `redis.enabled: true`)
+
+- [ ] **Step 1: Enable redis in prd values**
+
+In `infra/app/values-prd.yaml`, add a top-level block (near the `postgresql:` block):
+
+```yaml
+redis:
+  enabled: true
+```
+
+- [ ] **Step 2: Confirm the prd render**
+
+Run:
+
+```bash
+cd charts/family-pickem
+helm template pickem-prd . -f ../../infra/app/values-prd.yaml | grep -A2 "name: REDIS_URL"
+```
+
+Expected: `value: "redis://pickem-prd-redis-master:6379/1"`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add infra/app/values-prd.yaml
+git commit -m "feat(prd): enable Redis in production (#93)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+This deploys to prd on the next GitHub Release (ArgoCD `pickem-prd` tracks releases).
+
+- [ ] **Step 4: Verify in the running prd cluster (post-release)**
+
+After the release syncs, repeat the dev verification against prd:
+
+```bash
+kubectl get pods -n pickem-prd | grep redis
+kubectl exec -n pickem-prd deploy/family-pickem-prd -- \
+  python pickem/manage.py shell -c \
+  "from django.core.cache import cache; cache.set('livecheck','ok',30); print('CACHE:', cache.get('livecheck'))"
+kubectl exec -n pickem-prd statefulset/pickem-prd-redis-master -- \
+  redis-cli -n 1 keys '*livecheck*'
+```
+
+Expected: Redis pod `Running`; `CACHE: ok`; the key is present in Redis DB 1.
+
+---
+
+## Self-Review
+
+**Spec coverage (Phase 1 of the design doc):**
+- "Add a Redis subchart to the Helm chart (dev + prd)" → Tasks 2, 3, 4. ✓
+- "Repoint `CACHES['default']` from `FileBasedCache` to `django-redis`" → Task 1. ✓
+- "Redis serves two roles: shared cache and pub/sub broker" → cache used now (Task 1); broker DBs reserved via the DB-index comment (Task 2 Step 3). ✓
+- "Done when: cache works cross-request/cross-pod and Redis reachable from pods" → Task 3/4 Step 4 verification. ✓
+
+**Placeholder scan:** No TBD/TODO; every code and command step is concrete. ✓
+
+**Type/name consistency:** `build_caches(environ)` is defined in Task 1 and consumed by settings in the same task; `REDIS_URL` env produced in Task 2 matches the key `build_caches` reads; service name `{release}-redis-master` is used consistently in the template and all verification commands. ✓
+
+**Notable risk:** Bitnami image pullability (flagged in Task 3 Step 4) is the one item that may need real-cluster adjustment; it is gated in dev before prd.

--- a/docs/superpowers/plans/2026-08-02-live-updates-phase1-redis.md
+++ b/docs/superpowers/plans/2026-08-02-live-updates-phase1-redis.md
@@ -4,18 +4,18 @@
 
 **Goal:** Stand up a shared Redis instance and repoint Django's default cache at it, so the app has a cross-request/cross-replica cache and a broker that later phases use for live-update pub/sub.
 
-**Architecture:** Add a Bitnami Redis subchart to the Helm chart (opt-in per environment). The Django app selects its cache backend at startup: Redis when `REDIS_URL` is set, otherwise the existing file-based cache — so local dev and the test suite need no external services. The `REDIS_URL` is derived in the deployment template from the Helm release name, matching Bitnami's `{release}-redis-master` service.
+**Architecture:** Redis runs as a small self-managed Deployment + Service inside the Helm chart, using the official `redis` image (opt-in per environment). We deliberately do NOT use the Bitnami Redis subchart — Bitnami deprecated its free catalog (Aug 2025), moving versioned image tags to the frozen `bitnamilegacy` repo. The Django app selects its cache backend at startup: Redis when `REDIS_URL` is set, otherwise the existing file-based cache — so local dev and the test suite need no external services. `REDIS_URL` is derived in the deployment template from the chart fullname, matching our own `{fullname}-redis` service.
 
-**Tech Stack:** Django 5.2, django-redis, Bitnami Redis Helm subchart, Helm, ArgoCD GitOps, uv.
+**Tech Stack:** Django 5.2, django-redis, official Redis image (self-managed Deployment), Helm, ArgoCD GitOps, uv.
 
 ## Global Constraints
 
 - Python `>=3.12`; Django `5.2.16`. (`pyproject.toml`)
 - All Python deps are pinned to exact versions in `pyproject.toml` and locked in `uv.lock`; add deps with `uv add <pkg>==<version>` (never hand-edit the lock). (`pyproject.toml`)
 - Tests run against SQLite via `--settings=pickem.test_settings` from the `pickem/` directory. (`pickem/pickem/test_settings.py`)
-- Bitnami subchart resources are named `{release}-<subchart>` where release = `pickem-prd` / `pickem-dev` (NOT `fullnameOverride`). The Redis primary service is therefore `pickem-prd-redis-master` / `pickem-dev-redis-master`. (memory: Bitnami subchart naming; `infra/argocd/applications/pickem-prd.yaml`)
-- Do NOT hardcode ArgoCD chart `targetRevision` values; the release workflow manages them. Pinning a *subchart dependency version* inside `charts/family-pickem/Chart.yaml` is fine and expected.
-- Never edit K8s Secrets directly; secrets flow AWS Secrets Manager → ESO → K8s. (This phase needs NO new secret — see Task 2 note on auth.)
+- Postgres remains a Bitnami subchart named `{release}-postgresql` (release = `pickem-prd` / `pickem-dev`). Redis is a **self-managed** Deployment + Service named `{fullname}-redis`, where fullname = `fullnameOverride` = `family-pickem-prd` / `family-pickem-dev`. So the Redis service is `family-pickem-prd-redis` / `family-pickem-dev-redis`. (`infra/app/values-prd.yaml`; `charts/family-pickem/templates/_helpers.tpl`)
+- Do NOT hardcode ArgoCD chart `targetRevision` values; the release workflow manages them.
+- Never edit K8s Secrets directly; secrets flow AWS Secrets Manager → ESO → K8s. (This phase needs NO new secret — in-cluster Redis runs without auth; see Task 2.)
 - GitOps: dev tracks `main` automatically; prd tracks GitHub Releases. Enabling Redis in an environment happens by merging a values change, not by `kubectl` edits.
 
 ---
@@ -203,52 +203,106 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 
 ---
 
-### Task 2: Redis subchart + chart wiring (chart-side)
+### Task 2: Self-managed Redis Deployment + chart wiring (chart-side)
 
-Add the Bitnami Redis subchart to the Helm chart, default it off, and inject `REDIS_URL` into the web deployment when it is enabled.
+Add a small Redis Deployment + Service to the Helm chart using the official image, default it off, and inject `REDIS_URL` into the web deployment when it is enabled.
 
 **Files:**
-- Modify: `charts/family-pickem/Chart.yaml` (add `redis` dependency)
+- Create: `charts/family-pickem/templates/redis.yaml`
 - Modify: `charts/family-pickem/values.yaml` (add `redis:` block, default disabled)
 - Modify: `charts/family-pickem/templates/deployment.yaml` (add `REDIS_URL` env in the main container)
 
 **Interfaces:**
-- Produces: when `redis.enabled=true`, the web container gets env `REDIS_URL=redis://{{ .Release.Name }}-redis-master:6379/1`, consumed by `pickem.cache.build_caches` from Task 1.
+- Produces: when `redis.enabled=true`, a `{{ include "family-pickem.fullname" . }}-redis` Deployment + ClusterIP Service on port 6379, and the web container env `REDIS_URL=redis://{fullname}-redis:6379/1`, consumed by `pickem.cache.build_caches` from Task 1.
 
-- [ ] **Step 1: Add the Redis dependency to Chart.yaml**
-
-In `charts/family-pickem/Chart.yaml`, add to the `dependencies:` list (below the existing `postgresql` entry):
-
-```yaml
-  - name: "redis"
-    version: 17.11.3
-    repository: "https://charts.bitnami.com/bitnami"
-    condition: redis.enabled
-```
-
-- [ ] **Step 2: Add the redis values block**
+- [ ] **Step 1: Add the redis values block**
 
 In `charts/family-pickem/values.yaml`, add after the `postgresql:` block:
 
 ```yaml
 # Shared Redis: the Django cache now, and the pub/sub broker for live updates
-# later (#93). Disabled by default; enabled per environment in infra/app/.
-#
-# auth.enabled=false — Redis is only reachable inside the cluster network on
-# this private single-node cluster. Enable auth.enabled + an existingSecret
-# (sourced from AWS Secrets Manager) before ever exposing it beyond the cluster.
-#
-# persistence disabled — the cache is ephemeral; nothing here must survive a
-# restart. Bitnami names the primary service {release}-redis-master.
+# later (#93). Self-managed (NOT the Bitnami subchart — Bitnami deprecated its
+# free catalog in Aug 2025). Disabled by default; enabled per environment in
+# infra/app/. Ephemeral: no persistence, since it is only a cache/broker.
+# Reachable only inside the cluster network, so it runs without auth; add auth
+# (a password from AWS Secrets Manager via ESO) before ever exposing it.
 redis:
   enabled: false
-  architecture: standalone
-  auth:
-    enabled: false
-  master:
-    persistence:
-      enabled: false
+  image: "redis:7.4-alpine"
+  resources: {}
 ```
+
+- [ ] **Step 2: Create the Redis Deployment + Service template**
+
+Create `charts/family-pickem/templates/redis.yaml`:
+
+```yaml
+{{- if .Values.redis.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "family-pickem.fullname" . }}-redis
+  labels:
+    {{- include "family-pickem.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  replicas: 1
+  # Recreate: a single ephemeral cache instance; never run two at once.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "family-pickem.name" . }}-redis
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "family-pickem.name" . }}-redis
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: redis
+    spec:
+      containers:
+        - name: redis
+          image: {{ .Values.redis.image | quote }}
+          imagePullPolicy: IfNotPresent
+          # Ephemeral cache/broker: disable RDB snapshots and AOF entirely.
+          args: ["--save", "", "--appendonly", "no"]
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: redis
+            initialDelaySeconds: 10
+          readinessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 5
+          resources:
+            {{- toYaml .Values.redis.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "family-pickem.fullname" . }}-redis
+  labels:
+    {{- include "family-pickem.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  type: ClusterIP
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: redis
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: {{ include "family-pickem.name" . }}-redis
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+```
+
+> Why explicit `-redis` selector labels rather than the shared `selectorLabels` helper: the web Deployment/Service select on `name`+`instance` only. If the Redis pod carried those same two labels, the web Service would route traffic to it. The distinct `{{ name }}-redis` value keeps the two selectors from overlapping.
 
 - [ ] **Step 3: Inject REDIS_URL into the deployment**
 
@@ -256,39 +310,39 @@ In `charts/family-pickem/templates/deployment.yaml`, in the **main app container
 
 ```yaml
           {{- if .Values.redis.enabled }}
-          # Shared Redis cache/broker. Host follows Bitnami's
-          # {release}-redis-master service; DB 1 is the Django cache, later
-          # phases use other DB indexes for pub/sub.
+          # Shared Redis cache/broker (self-managed; see templates/redis.yaml).
+          # DB 1 is the Django cache; later phases use other DB indexes for pub/sub.
           - name: REDIS_URL
-            value: "redis://{{ .Release.Name }}-redis-master:6379/1"
+            value: "redis://{{ include "family-pickem.fullname" . }}-redis:6379/1"
           {{- end }}
 ```
 
-- [ ] **Step 4: Fetch the subchart and lint**
-
-Run:
-
-```bash
-helm repo add bitnami https://charts.bitnami.com/bitnami
-cd charts/family-pickem && helm dependency build
-helm lint . -f ../../infra/app/values-prd.yaml --set redis.enabled=true
-```
-
-Expected: `helm dependency build` downloads `redis-17.11.3.tgz` into `charts/family-pickem/charts/`; `helm lint` reports `0 chart(s) failed`.
-
-- [ ] **Step 5: Verify the rendered REDIS_URL and subchart**
+- [ ] **Step 4: Lint the chart**
 
 Run:
 
 ```bash
 cd charts/family-pickem
+helm lint . -f ../../infra/app/values-prd.yaml --set redis.enabled=true
+```
+
+Expected: `0 chart(s) failed`. (No `helm dependency build` needed — Redis is now a first-party template, not a subchart.)
+
+- [ ] **Step 5: Verify the rendered output**
+
+Run:
+
+```bash
+cd charts/family-pickem
+# REDIS_URL points at our own service
 helm template pickem-prd . -f ../../infra/app/values-prd.yaml --set redis.enabled=true | grep -A2 "name: REDIS_URL"
-helm template pickem-prd . -f ../../infra/app/values-prd.yaml --set redis.enabled=true | grep "kind: StatefulSet"
+# The Redis Deployment + Service render
+helm template pickem-prd . -f ../../infra/app/values-prd.yaml --set redis.enabled=true | grep -E "name: family-pickem-prd-redis"
 ```
 
 Expected:
-- The first command prints `value: "redis://pickem-prd-redis-master:6379/1"`.
-- The second shows the Bitnami Redis `StatefulSet` is rendered.
+- The first command prints `value: "redis://family-pickem-prd-redis:6379/1"`.
+- The second shows the `family-pickem-prd-redis` Deployment and Service names.
 
 Also confirm the default is still off:
 
@@ -301,17 +355,16 @@ Expected: prints `REDIS_URL absent by default — correct`.
 - [ ] **Step 6: Commit**
 
 ```bash
-git add charts/family-pickem/Chart.yaml charts/family-pickem/Chart.lock charts/family-pickem/values.yaml charts/family-pickem/templates/deployment.yaml
-git commit -m "feat(chart): add optional Redis subchart and REDIS_URL wiring
+git add charts/family-pickem/values.yaml charts/family-pickem/templates/redis.yaml charts/family-pickem/templates/deployment.yaml
+git commit -m "feat(chart): add self-managed Redis Deployment and REDIS_URL wiring
 
-Bitnami Redis subchart gated on redis.enabled (default off). When enabled,
-the web deployment gets REDIS_URL pointing at the {release}-redis-master
-service. No new secret: in-cluster Redis runs with auth disabled. (#93)
+Small first-party Redis Deployment + Service on the official redis image,
+gated on redis.enabled (default off). Avoids the deprecated Bitnami subchart.
+When enabled, the web deployment gets REDIS_URL pointing at the
+{fullname}-redis service. In-cluster Redis runs without auth. (#93)
 
 Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 ```
-
-> Note: `helm dependency build` may also create/update `charts/family-pickem/Chart.lock`. Do **not** commit the downloaded `charts/*.tgz` if a `.helmignore`/`.gitignore` already excludes them; check `git status` and add only `Chart.lock` if the tgz is ignored. If the tgz is normally committed in this repo, add it too.
 
 ---
 
@@ -340,7 +393,7 @@ cd charts/family-pickem
 helm template pickem-dev . -f ../../infra/app/values-dev.yaml | grep -A2 "name: REDIS_URL"
 ```
 
-Expected: `value: "redis://pickem-dev-redis-master:6379/1"`.
+Expected: `value: "redis://family-pickem-dev-redis:6379/1"`.
 
 - [ ] **Step 3: Commit and push (dev auto-deploys from main)**
 
@@ -365,13 +418,11 @@ kubectl exec -n pickem-dev deploy/family-pickem-dev -- \
   python pickem/manage.py shell -c \
   "from django.core.cache import cache; cache.set('livecheck','ok',30); print('CACHE:', cache.get('livecheck'))"
 # The key is visible in Redis DB 1
-kubectl exec -n pickem-dev statefulset/pickem-dev-redis-master -- \
+kubectl exec -n pickem-dev deploy/family-pickem-dev-redis -- \
   redis-cli -n 1 keys '*livecheck*'
 ```
 
-Expected: the Redis pod is `Running`; the shell prints `CACHE: ok`; `redis-cli` lists a `...livecheck` key.
-
-> **Risk to watch here (most likely failure point):** a 2-year-old Bitnami image tag may no longer be pullable after Bitnami's 2025 registry changes. If the Redis pod is `ImagePullBackOff`, override the image in `values.yaml`'s `redis:` block to the still-published location — e.g. set `redis.image.registry: docker.io` and `redis.image.repository: bitnamilegacy/redis` — or bump the subchart to a newer version whose images are published, then re-run Task 2 Steps 4-5. Resolve this in dev before Task 4.
+Expected: the Redis pod is `Running`; the shell prints `CACHE: ok`; `redis-cli` lists a `...livecheck` key. (The official `redis` image is upstream-maintained, so there is no image-pull deprecation risk here.)
 
 ---
 
@@ -400,7 +451,7 @@ cd charts/family-pickem
 helm template pickem-prd . -f ../../infra/app/values-prd.yaml | grep -A2 "name: REDIS_URL"
 ```
 
-Expected: `value: "redis://pickem-prd-redis-master:6379/1"`.
+Expected: `value: "redis://family-pickem-prd-redis:6379/1"`.
 
 - [ ] **Step 3: Commit**
 
@@ -422,7 +473,7 @@ kubectl get pods -n pickem-prd | grep redis
 kubectl exec -n pickem-prd deploy/family-pickem-prd -- \
   python pickem/manage.py shell -c \
   "from django.core.cache import cache; cache.set('livecheck','ok',30); print('CACHE:', cache.get('livecheck'))"
-kubectl exec -n pickem-prd statefulset/pickem-prd-redis-master -- \
+kubectl exec -n pickem-prd deploy/family-pickem-prd-redis -- \
   redis-cli -n 1 keys '*livecheck*'
 ```
 
@@ -433,13 +484,13 @@ Expected: Redis pod `Running`; `CACHE: ok`; the key is present in Redis DB 1.
 ## Self-Review
 
 **Spec coverage (Phase 1 of the design doc):**
-- "Add a Redis subchart to the Helm chart (dev + prd)" → Tasks 2, 3, 4. ✓
+- "Add a Redis subchart to the Helm chart (dev + prd)" → satisfied via a self-managed Deployment instead of the Bitnami subchart (Tasks 2, 3, 4), a deliberate deviation because Bitnami deprecated its free catalog. ✓
 - "Repoint `CACHES['default']` from `FileBasedCache` to `django-redis`" → Task 1. ✓
 - "Redis serves two roles: shared cache and pub/sub broker" → cache used now (Task 1); broker DBs reserved via the DB-index comment (Task 2 Step 3). ✓
 - "Done when: cache works cross-request/cross-pod and Redis reachable from pods" → Task 3/4 Step 4 verification. ✓
 
 **Placeholder scan:** No TBD/TODO; every code and command step is concrete. ✓
 
-**Type/name consistency:** `build_caches(environ)` is defined in Task 1 and consumed by settings in the same task; `REDIS_URL` env produced in Task 2 matches the key `build_caches` reads; service name `{release}-redis-master` is used consistently in the template and all verification commands. ✓
+**Type/name consistency:** `build_caches(environ)` is defined in Task 1 and consumed by settings in the same task; `REDIS_URL` env produced in Task 2 matches the key `build_caches` reads; the service name `{fullname}-redis` (= `family-pickem-{env}-redis`) is used consistently across the template, the `REDIS_URL` value, and all verification commands. Redis selector labels (`{name}-redis`) are deliberately distinct from the web selector to avoid overlap. ✓
 
-**Notable risk:** Bitnami image pullability (flagged in Task 3 Step 4) is the one item that may need real-cluster adjustment; it is gated in dev before prd.
+**Notable deviation from spec:** self-managed Redis instead of the Bitnami subchart, decided after confirming Bitnami's Aug 2025 free-catalog deprecation. This removes the previously-flagged image-pull risk entirely (official `redis` image is upstream-maintained).

--- a/docs/superpowers/plans/2026-08-02-live-updates-phase1-redis.md
+++ b/docs/superpowers/plans/2026-08-02-live-updates-phase1-redis.md
@@ -430,8 +430,25 @@ Expected: the Redis pod is `Running`; the shell prints `CACHE: ok`; `redis-cli` 
 
 Only after dev is verified. This is the production rollout gate.
 
+**Hardening prerequisites (required before prd-enable — do NOT enable prd without these):**
+Redis in dev runs in-cluster with no auth, which is acceptable for a private,
+single-node, first-party dev cluster. Production must not. Before setting
+`redis.enabled: true` in prd, land both:
+1. **NetworkPolicy** — a default-deny ingress policy for the Redis pod that
+   allows TCP 6379 only from the web (and, post-#95, scheduler) pod selector.
+   Effective only if the cluster CNI enforces NetworkPolicy — confirm the CNI
+   (Calico/Cilium enforce; Flannel does not) or treat auth as the primary control.
+2. **Auth** — a Redis password sourced from AWS Secrets Manager via ESO, wired
+   into the Redis pod (`--requirepass` / config) and into `REDIS_URL`
+   (`redis://:<password>@…`). Follow the AWS-SM → ESO → K8s-secret pattern; never
+   hardcode. (Raised by CodeRabbit on PR #141; deliberately deferred from the
+   dev rollout.)
+Set Redis `resources` are already defined in `values.yaml`; review the maxmemory/
+limit sizing for prd load before enabling.
+
 **Files:**
 - Modify: `infra/app/values-prd.yaml` (set `redis.enabled: true`)
+- Create: NetworkPolicy template + auth wiring (see prerequisites above)
 
 - [ ] **Step 1: Enable redis in prd values**
 

--- a/docs/superpowers/specs/2026-08-02-live-updates-design.md
+++ b/docs/superpowers/specs/2026-08-02-live-updates-design.md
@@ -1,0 +1,143 @@
+# Live Updates (SSE push) — Design
+
+**Date:** 2026-08-02
+**Status:** Approved (design); pending spec review
+**Related issues:** #138 (async views for /scores/), #93 (shared cache / Redis), #95 (scheduler extraction + web autoscaling)
+
+## Goal
+
+Make Family Pickem *feel live*. During games, viewers should see — without reloading —
+game scores/status, and (as picks get graded) their points, wins/losses, and
+leaderboard rank, on both the dedicated scores page (`/scores/`) and the lobby
+(homepage). Target latency: **< 2s** from when our system learns of a change to
+when it appears on screen.
+
+## Why the current approach is not enough
+
+- **Frontend:** `scores.html` polls its own full URL every 30s, re-downloads the
+  entire rendered HTML page, parses it with `DOMParser`, and diffs game cards.
+  Heavy per client, and caps freshness at ~30s.
+- **Backend:** the in-process APScheduler runs `update_games` every 60s, so the
+  DB is up to ~60s stale. Combined worst case ~90s.
+- **Infra ceiling:** WSGI served by `manage.py runserver`, a single web replica,
+  file-based cache (`/tmp/django_cache`, no Redis), no ASGI/Channels. None of
+  this can hold many long-lived push connections or coordinate across processes.
+
+## Chosen approach
+
+**Server-Sent Events (SSE) push, on a scaled-out stack.** SSE is the right fit:
+the data flow is purely server→browser (no client→server messaging), SSE is
+lighter than WebSockets/Channels, runs over plain HTTP, and auto-reconnects.
+
+The push layer can only be as fresh as the database, so faster `update_games`
+during live windows is a required companion, and a shared broker (Redis) is
+required so the scheduler process can notify browser connections held by any web
+replica.
+
+## Decomposition & build order
+
+Three sequential sub-projects, each with its own spec → plan → implementation:
+
+### Phase 1 — Redis (#93)
+- Add a Redis subchart to the Helm chart (dev + prd); expose connection details
+  via env/ESO.
+- Repoint `CACHES['default']` from `FileBasedCache` to `django-redis`.
+- Redis serves two roles henceforth: shared Django cache **and** pub/sub broker
+  for live events.
+- **Done when:** cache works cross-request/cross-pod and Redis is reachable from
+  pods.
+
+### Phase 2 — Scheduler split + web autoscaling (#95)
+- New single-replica `scheduler` Deployment: `RUN_SCHEDULER=true`, `replicas: 1`,
+  no HPA. Only this pod writes the APScheduler `DjangoJobStore`.
+- Web Deployment: `RUN_SCHEDULER=false`, `autoscaling.enabled=true` + HPA.
+- Remove the Helm `fail` guard forbidding `scheduler.enabled && autoscaling.enabled`
+  (now safe because they are separate deployments).
+- **Done when:** the HPA scales web pods while exactly one scheduler runs the
+  pipeline.
+
+### Phase 3 — Live push feature
+The main event. Depends on Phases 1 & 2 (and on the Django 5.2 upgrade for async
+views/streaming). Detailed below.
+
+## Phase 3 detail
+
+### A. Backend cadence — faster freshness
+
+Split work by what actually changes when:
+
+- **During live play, only scores/status change.** A dedicated **fast scores job**
+  on the scheduler runs `update_games` every **~10s** while any game in the
+  current week is `inprogress`; when no game is live it idles back to the normal
+  60s cadence. Self-adjusting — no fast polling outside game windows.
+- **Points / ranks / W-L change only when a game goes final.** The heavy
+  downstream (`update_picks → update_standings → update_rankings → update_stats`)
+  does **not** run every 10s. It fires when the fast job detects a game flipping
+  to `finished`, scoped to the affected pool/week.
+- **ESPN reality:** the source feed refreshes roughly every 15–20s, so ~10s is
+  the practical floor; faster just re-fetches unchanged data.
+
+### B. Publish-on-write
+
+After the scheduler writes fresh data, it `PUBLISH`es a compact JSON event to
+Redis. Two channel families:
+
+- `scores:{season}:{week}` — score/status deltas (not pool-specific).
+- `standings:{pool}:{season}:{week}` — points / ranks / W-L deltas (pool-scoped).
+
+Events carry only changed fields, e.g.
+`{game_id, home, away, status, quarter, clock}` — **not** rendered HTML.
+
+### C. Transport — ASGI + SSE
+
+- Switch the web process from `manage.py runserver` (WSGI) to **uvicorn (ASGI)**.
+  Required for scale regardless; lets one replica hold many live connections
+  cheaply via async.
+- One async view, `GET /events/`, that:
+  - Authenticates via the existing session, then subscribes the browser **only**
+    to channels it is allowed: the user's pools + the public scores channel.
+    Enforces pool membership so nobody streams another family's standings.
+  - Uses a **per-replica broadcaster**: one Redis subscription per replica fans
+    out to all local connections, instead of one Redis connection per browser.
+  - Sends a keepalive comment every ~20s so Cloudflare/proxies don't drop idle
+    streams; sets `X-Accel-Buffering: no` to defeat buffering.
+  - Relies on EventSource's built-in auto-reconnect for dropped connections.
+
+### D. Client
+
+- Replace the 30s full-HTML re-fetch in `scores.html` with a single
+  `EventSource('/events/')`.
+- On (re)connect, do **one** snapshot fetch of current state, then apply streamed
+  deltas by patching elements keyed on `data-game-id` / `data-user-id`.
+- The same handler set powers the lobby tiles (scores preview + standings
+  preview). Retire the `DOMParser` diffing path.
+
+### E. Error handling & testing
+
+- **Graceful degradation:** if Redis/SSE is unavailable, the client falls back to
+  a slow (~30s) poll of the snapshot endpoint. The page degrades, never breaks.
+- **Async-safety:** the `/events/` path must be async-safe. Audit the two sync
+  custom middlewares (`pickem_homepage/middleware.py`) and either make them
+  async-compatible or exempt the streaming path.
+- **Tests:**
+  - Unit: live-window detection and fast/slow cadence switching; event payload
+    shape.
+  - Async: `/events/` auth scoping — a user must never receive another pool's
+    channel.
+  - Client: fallback-to-poll when the stream is unavailable.
+
+## Notable risks
+
+- **Cloudflare + SSE:** Cloudflare proxies SSE, but long-lived streams need the
+  keepalive + no-buffering handling above to stay reliable. Most likely area to
+  need real-environment tuning.
+- **Middleware async-safety:** sync-only middleware around an async streaming view
+  can force buffering/blocking; must be handled explicitly.
+- **Connection budget:** at ~30–150 concurrent viewers, one uvicorn replica per
+  the per-replica-broadcaster model is comfortable, but load-test before launch.
+
+## Out of scope
+
+- Bidirectional features (live chat/reactions) — would argue for WebSockets;
+  not needed now.
+- Against-the-spread / confidence pick types and other unrelated scoring work.

--- a/docs/superpowers/specs/2026-08-02-live-updates-design.md
+++ b/docs/superpowers/specs/2026-08-02-live-updates-design.md
@@ -42,8 +42,10 @@ Three sequential sub-projects, each with its own spec → plan → implementatio
 - Add Redis as a **self-managed** Deployment + Service in the Helm chart (dev +
   prd), using the official `redis` image. Deliberately *not* the Bitnami subchart:
   Bitnami deprecated its free catalog (Aug 2025), moving versioned image tags to
-  the frozen `bitnamilegacy` repo. In-cluster Redis runs without auth (network-
-  internal); add auth from AWS SM/ESO before ever exposing it.
+  the frozen `bitnamilegacy` repo. In-cluster Redis runs without auth for dev
+  (network-internal, private single-node cluster). **Before enabling prd**, add a
+  NetworkPolicy (web/scheduler pods → Redis:6379 only) and Redis auth from
+  AWS SM/ESO — a hard gate captured in the Phase 1 plan's Task 4.
 - Repoint `CACHES['default']` from `FileBasedCache` to `django-redis`.
 - Redis serves two roles henceforth: shared Django cache **and** pub/sub broker
   for live events.

--- a/docs/superpowers/specs/2026-08-02-live-updates-design.md
+++ b/docs/superpowers/specs/2026-08-02-live-updates-design.md
@@ -39,8 +39,11 @@ replica.
 Three sequential sub-projects, each with its own spec → plan → implementation:
 
 ### Phase 1 — Redis (#93)
-- Add a Redis subchart to the Helm chart (dev + prd); expose connection details
-  via env/ESO.
+- Add Redis as a **self-managed** Deployment + Service in the Helm chart (dev +
+  prd), using the official `redis` image. Deliberately *not* the Bitnami subchart:
+  Bitnami deprecated its free catalog (Aug 2025), moving versioned image tags to
+  the frozen `bitnamilegacy` repo. In-cluster Redis runs without auth (network-
+  internal); add auth from AWS SM/ESO before ever exposing it.
 - Repoint `CACHES['default']` from `FileBasedCache` to `django-redis`.
 - Redis serves two roles henceforth: shared Django cache **and** pub/sub broker
   for live events.

--- a/infra/app/values-dev.yaml
+++ b/infra/app/values-dev.yaml
@@ -35,6 +35,9 @@ postgresql:
       storageClass: "manual"
       size: 10Gi
 
+redis:
+  enabled: true
+
 # In-process scheduler replaces the legacy cron.sh CronJob (now removed).
 scheduler:
   enabled: true

--- a/pickem/pickem/cache.py
+++ b/pickem/pickem/cache.py
@@ -1,0 +1,42 @@
+"""Cache backend selection.
+
+Uses Redis (shared across requests and replicas) when ``REDIS_URL`` is set,
+otherwise falls back to the local file-based cache so local development and the
+test suite need no external services.
+
+See docs/superpowers/specs/2026-08-02-live-updates-design.md (Phase 1) and
+issue #93.
+"""
+
+
+def build_caches(environ):
+    """Return a Django ``CACHES`` dict based on the given environment mapping.
+
+    ``environ`` is typically ``os.environ``. When ``REDIS_URL`` is a non-blank
+    string the default cache is Redis (via django-redis); otherwise it is the
+    file-based cache at ``/tmp/django_cache``.
+    """
+    redis_url = environ.get('REDIS_URL', '').strip()
+    if redis_url:
+        return {
+            'default': {
+                'BACKEND': 'django_redis.cache.RedisCache',
+                'LOCATION': redis_url,
+                'TIMEOUT': 300,  # 5 minutes
+                'OPTIONS': {
+                    'CLIENT_CLASS': 'django_redis.client.DefaultClient',
+                    # A cache outage must degrade to "no cache", never 500s.
+                    'IGNORE_EXCEPTIONS': True,
+                },
+            }
+        }
+    return {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
+            'LOCATION': '/tmp/django_cache',
+            'TIMEOUT': 300,  # 5 minutes
+            'OPTIONS': {
+                'MAX_ENTRIES': 1000,
+            },
+        }
+    }

--- a/pickem/pickem/settings.py
+++ b/pickem/pickem/settings.py
@@ -13,6 +13,8 @@ https://docs.djangoproject.com/en/3.0/ref/settings/
 import os
 import requests
 
+from .cache import build_caches
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  
 
@@ -131,14 +133,17 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 
-# Default cache (file-based; also used by Django internals).
+# Cache backend: Redis when REDIS_URL is set (see pickem/cache.py and issue
+# #93); the file-based cache otherwise, so local dev and tests need no external
+# services.
 # NOTE: application-level rate limiting was removed — request throttling is
 # handled at the edge by a Cloudflare rate-limiting rule instead.
-from .cache import build_caches
-
-# Redis when REDIS_URL is set (see pickem/cache.py and issue #93); the
-# file-based cache otherwise, so local dev and tests need no external services.
 CACHES = build_caches(os.environ)
+
+# IGNORE_EXCEPTIONS makes a Redis outage degrade to "no cache" rather than
+# raising 500s; pair it with this so the swallowed connection errors are still
+# logged (console/superadmin/Sentry via the root logger) instead of vanishing.
+DJANGO_REDIS_LOG_IGNORED_EXCEPTIONS = True
 
 ROOT_URLCONF = 'pickem.urls'
 

--- a/pickem/pickem/settings.py
+++ b/pickem/pickem/settings.py
@@ -134,16 +134,11 @@ MIDDLEWARE = [
 # Default cache (file-based; also used by Django internals).
 # NOTE: application-level rate limiting was removed — request throttling is
 # handled at the edge by a Cloudflare rate-limiting rule instead.
-CACHES = {
-    'default': {
-        'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
-        'LOCATION': '/tmp/django_cache',
-        'TIMEOUT': 300,  # 5 minutes
-        'OPTIONS': {
-            'MAX_ENTRIES': 1000,
-        }
-    }
-}
+from .cache import build_caches
+
+# Redis when REDIS_URL is set (see pickem/cache.py and issue #93); the
+# file-based cache otherwise, so local dev and tests need no external services.
+CACHES = build_caches(os.environ)
 
 ROOT_URLCONF = 'pickem.urls'
 

--- a/pickem/pickem_api/tests/test_cache_config.py
+++ b/pickem/pickem_api/tests/test_cache_config.py
@@ -1,0 +1,30 @@
+from django.test import SimpleTestCase
+
+from pickem.cache import build_caches
+
+
+# NOTE: wrapped in a SimpleTestCase (rather than bare module-level functions)
+# because this repo's test suite runs via `manage.py test`, which uses
+# unittest discovery — bare `def test_...():` functions are silently never
+# collected (0 tests run). No other test module in this codebase uses the
+# bare-function style. The assertions/logic below are unchanged.
+class BuildCachesTests(SimpleTestCase):
+    def test_uses_filebased_cache_when_no_redis_url(self):
+        caches = build_caches({})
+        assert caches['default']['BACKEND'] == (
+            'django.core.cache.backends.filebased.FileBasedCache'
+        )
+
+    def test_uses_redis_when_redis_url_set(self):
+        caches = build_caches({'REDIS_URL': 'redis://example:6379/1'})
+        default = caches['default']
+        assert default['BACKEND'] == 'django_redis.cache.RedisCache'
+        assert default['LOCATION'] == 'redis://example:6379/1'
+        # A cache outage must degrade to "no cache", never surface as a 500.
+        assert default['OPTIONS']['IGNORE_EXCEPTIONS'] is True
+
+    def test_blank_redis_url_falls_back_to_filebased(self):
+        caches = build_caches({'REDIS_URL': '   '})
+        assert caches['default']['BACKEND'] == (
+            'django.core.cache.backends.filebased.FileBasedCache'
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "charset-normalizer==2.1.1",
     "cryptography==48.0.1",
     "defusedxml==0.7.1",
+    "django-redis==5.4.0",
     "Django==5.2.16",
     "django-allauth==65.14.1",
     "django-apscheduler==0.7.0",

--- a/uv.lock
+++ b/uv.lock
@@ -254,6 +254,19 @@ wheels = [
 ]
 
 [[package]]
+name = "django-redis"
+version = "5.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+    { name = "redis" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/9d/2272742fdd9d0a9f0b28cd995b0539430c9467a2192e4de2cea9ea6ad38c/django-redis-5.4.0.tar.gz", hash = "sha256:6a02abaa34b0fea8bf9b707d2c363ab6adc7409950b2db93602e6cb292818c42", size = 52567 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/f1/63caad7c9222c26a62082f4f777de26389233b7574629996098bf6d25a4d/django_redis-5.4.0-py3-none-any.whl", hash = "sha256:ebc88df7da810732e2af9987f7f426c96204bf89319df4c6da6ca9a2942edd5b", size = 31119 },
+]
+
+[[package]]
 name = "django-storages"
 version = "1.13.1"
 source = { registry = "https://pypi.org/simple" }
@@ -295,6 +308,7 @@ dependencies = [
     { name = "django" },
     { name = "django-allauth" },
     { name = "django-apscheduler" },
+    { name = "django-redis" },
     { name = "django-storages" },
     { name = "django-tables2" },
     { name = "idna" },
@@ -343,6 +357,7 @@ requires-dist = [
     { name = "django", specifier = "==5.2.16" },
     { name = "django-allauth", specifier = "==65.14.1" },
     { name = "django-apscheduler", specifier = "==0.7.0" },
+    { name = "django-redis", specifier = "==5.4.0" },
     { name = "django-storages", specifier = "==1.13.1" },
     { name = "django-tables2", specifier = "==2.4.1" },
     { name = "idna", specifier = "==3.15" },
@@ -575,6 +590,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/94/f0/909f94fea74759654390a3e1a9e4e185b6cd9aa810e533e3586f39da3097/pytz_deprecation_shim-0.1.0.post0.tar.gz", hash = "sha256:af097bae1b616dde5c5744441e2ddc69e74dfdcb0c263129610d85b87445a59d", size = 60190 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/73/3eaab547ca809754e67e06871cff0fc962bafd4b604e15f31896a0f94431/pytz_deprecation_shim-0.1.0.post0-py2.py3-none-any.whl", hash = "sha256:8314c9692a636c8eb3bda879b9f119e350e93223ae83e70e80c31675a0fdc1a6", size = 15734 },
+]
+
+[[package]]
+name = "redis"
+version = "8.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/99/604f0b666d4c616d891cf77ebb9db6bb21601344c051aebf1b72b9ff915f/redis-8.1.0.tar.gz", hash = "sha256:6e1a19beef9225c83efd689c7e6b7da2d5215b1f42cd13b7fc3714d0a09c7b25", size = 5254356 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/9d/c5731f6e3608663d4d3656fd8d3aecee8b509c3082818f5a13eae925baea/redis-8.1.0-py3-none-any.whl", hash = "sha256:a4fe1aac3d3b3cc791d4b3d5931c5a956045dc951ee74d1c913ee3ac4d2ee9fb", size = 560618 },
 ]
 
 [[package]]


### PR DESCRIPTION
## What & why

Phase 1 of the **live updates** initiative (design: `docs/superpowers/specs/2026-08-02-live-updates-design.md`). Stands up a shared Redis instance and repoints Django's default cache at it — the foundation for cross-replica coordination and the pub/sub broker later phases use to push live scores/points/ranks. Closes the cache half of #93.

## Changes

- **App-side cache selection** (`pickem/pickem/cache.py`): new `build_caches(environ)` helper — uses `django-redis` when `REDIS_URL` is set, else the existing file-based cache. Local dev and tests are byte-for-byte unchanged (no `REDIS_URL` → same file-based config as before). `IGNORE_EXCEPTIONS: True` so a Redis outage degrades to "no cache" rather than 500s, paired with `DJANGO_REDIS_LOG_IGNORED_EXCEPTIONS` so those outages still get logged.
- **Self-managed Redis in the chart** (`charts/family-pickem/templates/redis.yaml`): a small Deployment + Service on the official `redis:7.4-alpine` image, gated on `redis.enabled` (default off). **Not** the Bitnami subchart — Bitnami deprecated its free catalog (Aug 2025), freezing versioned image tags in `bitnamilegacy`. `REDIS_URL` is auto-derived from the chart fullname; Redis pod selector labels are deliberately distinct from the web pods' so the web Service can't route to Redis.
- **Dev enabled** (`infra/app/values-dev.yaml`): `redis.enabled: true`.

## Deferred (deploy-gated, not in this PR)

- Enabling Redis in **prd** (Task 4) — gated behind in-cluster dev verification, and set Redis `resources` requests/limits first.
- Post-merge `kubectl` verification that the app round-trips the cache through Redis.

## Testing

- `manage.py check` clean; `makemigrations --check` → no changes.
- Full suite: **873 tests, OK (6 skipped)**.
- `helm lint` clean; `helm template` renders `REDIS_URL=redis://family-pickem-dev-redis:6379/1` and the Redis objects only when enabled.
- Reviewed via SDD final review (opus) + ship-it review agents (code/tests/error-handling) — no Critical/Important outstanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Redis support for shared caching and messaging.
  * Added an in-cluster Redis service for development and configurable deployments.
  * Automatically falls back to file-based caching when Redis is unavailable or not configured.

* **Documentation**
  * Documented Redis caching configuration and the planned live-update architecture.

* **Tests**
  * Added coverage for Redis configuration, connection handling, and file-cache fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->