### PR TITLE
Enable Redis in prd with auth (#93)

### DIFF
--- a/charts/family-pickem/templates/deployment.yaml
+++ b/charts/family-pickem/templates/deployment.yaml
@@ -74,6 +74,8 @@ spec:
           # REDIS_URL by Kubernetes at pod start, so the credential never appears
           # in a rendered manifest. DB 1 is the Django cache; later phases use
           # other DB indexes for pub/sub.
+          # NOTE: this must be an explicit env entry (not just envFrom) — $(VAR)
+          # interpolation only sees vars declared in this container's env list.
           - name: REDIS_PASSWORD
             valueFrom:
               secretKeyRef:

--- a/charts/family-pickem/templates/deployment.yaml
+++ b/charts/family-pickem/templates/deployment.yaml
@@ -70,9 +70,17 @@ spec:
             value: "{{ .Values.image.tag | default .Chart.AppVersion }}"
           {{- if .Values.redis.enabled }}
           # Shared Redis cache/broker (self-managed; see templates/redis.yaml).
-          # DB 1 is the Django cache; later phases use other DB indexes for pub/sub.
+          # REDIS_PASSWORD (from the -envvars secret via ESO) is interpolated into
+          # REDIS_URL by Kubernetes at pod start, so the credential never appears
+          # in a rendered manifest. DB 1 is the Django cache; later phases use
+          # other DB indexes for pub/sub.
+          - name: REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "family-pickem.fullname" . }}-envvars
+                key: REDIS_PASSWORD
           - name: REDIS_URL
-            value: "redis://{{ include "family-pickem.fullname" . }}-redis:6379/1"
+            value: "redis://:$(REDIS_PASSWORD)@{{ include "family-pickem.fullname" . }}-redis:6379/1"
           {{- end }}
           # The web tier never runs the pipeline — the dedicated scheduler
           # Deployment does (templates/scheduler-deployment.yaml). Explicit

--- a/charts/family-pickem/templates/redis.yaml
+++ b/charts/family-pickem/templates/redis.yaml
@@ -26,6 +26,15 @@ spec:
         - name: redis
           image: {{ .Values.redis.image | quote }}
           imagePullPolicy: IfNotPresent
+          # The `command:` below overrides the image entrypoint, which is what
+          # normally drops from root to the redis user (uid 999). Pin non-root
+          # explicitly so that hardening is preserved. (No persistence here, so
+          # no volume ownership to worry about.)
+          securityContext:
+            runAsUser: 999
+            runAsGroup: 1000
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
           # Require a password (REDIS_PASSWORD from the -envvars secret, sourced
           # from AWS Secrets Manager via ESO). Using `command` so the flag can
           # reference $REDIS_PASSWORD; the rest matches the ephemeral-cache config

--- a/charts/family-pickem/templates/redis.yaml
+++ b/charts/family-pickem/templates/redis.yaml
@@ -26,19 +26,27 @@ spec:
         - name: redis
           image: {{ .Values.redis.image | quote }}
           imagePullPolicy: IfNotPresent
-          # Ephemeral cache/broker: disable RDB snapshots and AOF, and bound the
-          # dataset with LRU eviction so Redis can never grow past its container
-          # limit and OOM the node. (allkeys-lru is safe here: DB 1 is a pure
-          # cache and pub/sub messages don't live in the keyspace.)
-          args:
-            - "--save"
-            - ""
-            - "--appendonly"
-            - "no"
-            - "--maxmemory"
-            - {{ .Values.redis.maxmemory | quote }}
-            - "--maxmemory-policy"
-            - {{ .Values.redis.maxmemoryPolicy | quote }}
+          # Require a password (REDIS_PASSWORD from the -envvars secret, sourced
+          # from AWS Secrets Manager via ESO). Using `command` so the flag can
+          # reference $REDIS_PASSWORD; the rest matches the ephemeral-cache config
+          # (no RDB/AOF; bounded memory with LRU eviction so Redis can't OOM the
+          # node — allkeys-lru is safe: DB 1 is a pure cache, pub/sub isn't keyed).
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "family-pickem.fullname" . }}-envvars
+                  key: REDIS_PASSWORD
+          command:
+            - sh
+            - -c
+            - >-
+              exec redis-server
+              --requirepass "$REDIS_PASSWORD"
+              --save ""
+              --appendonly no
+              --maxmemory {{ .Values.redis.maxmemory | quote }}
+              --maxmemory-policy {{ .Values.redis.maxmemoryPolicy | quote }}
           ports:
             - name: redis
               containerPort: 6379
@@ -49,7 +57,7 @@ spec:
             initialDelaySeconds: 10
           readinessProbe:
             exec:
-              command: ["redis-cli", "ping"]
+              command: ["sh", "-c", "redis-cli --no-auth-warning -a \"$REDIS_PASSWORD\" ping"]
             initialDelaySeconds: 5
           resources:
             {{- toYaml .Values.redis.resources | nindent 12 }}

--- a/charts/family-pickem/templates/scheduler-deployment.yaml
+++ b/charts/family-pickem/templates/scheduler-deployment.yaml
@@ -92,6 +92,8 @@ spec:
           {{- if .Values.redis.enabled }}
           # REDIS_PASSWORD interpolated into REDIS_URL by Kubernetes at pod start
           # (credential never rendered into a manifest). See templates/redis.yaml.
+          # NOTE: must be an explicit env entry (not just envFrom) — $(VAR)
+          # interpolation only sees vars declared in this container's env list.
           - name: REDIS_PASSWORD
             valueFrom:
               secretKeyRef:

--- a/charts/family-pickem/templates/scheduler-deployment.yaml
+++ b/charts/family-pickem/templates/scheduler-deployment.yaml
@@ -54,10 +54,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
-          {{- if .Values.redis.enabled }}
-          - name: REDIS_URL
-            value: "redis://{{ include "family-pickem.fullname" . }}-redis:6379/1"
-          {{- end }}
+          # The migrate-check init does not use Redis, so no REDIS_URL here.
           resources:
             {{- toYaml .Values.scheduler.resources | nindent 12 }}
       containers:
@@ -93,8 +90,15 @@ spec:
           - name: RUN_WEB_SERVER
             value: "true"
           {{- if .Values.redis.enabled }}
+          # REDIS_PASSWORD interpolated into REDIS_URL by Kubernetes at pod start
+          # (credential never rendered into a manifest). See templates/redis.yaml.
+          - name: REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "family-pickem.fullname" . }}-envvars
+                key: REDIS_PASSWORD
           - name: REDIS_URL
-            value: "redis://{{ include "family-pickem.fullname" . }}-redis:6379/1"
+            value: "redis://:$(REDIS_PASSWORD)@{{ include "family-pickem.fullname" . }}-redis:6379/1"
           {{- end }}
           ports:
             - name: http

--- a/infra/app/values-prd.yaml
+++ b/infra/app/values-prd.yaml
@@ -34,6 +34,10 @@ postgresql:
   primary:
     persistence:
       existingClaim: postgres-prd-pvc
+# Shared Redis (auth via REDIS_PASSWORD from AWS Secrets Manager / ESO).
+redis:
+  enabled: true
+
 # Runs the update pipeline in a dedicated single-replica scheduler Deployment
 # (RUN_SCHEDULER=true); the web tier runs RUN_SCHEDULER=false and can autoscale.
 scheduler:


### PR DESCRIPTION
## What & why

Completes Phase 1's deferred hardening gate: **enable Redis in production, with authentication**. Prerequisite for Phase 3 (SSE live-push uses Redis pub/sub in prod).

Per the earlier decision, the reliable control is **auth** (a NetworkPolicy would be no-op — no enforcing CNI detected on the v1.34 single-node cluster).

## Changes (chart + values only — no app code)

- **Redis requires a password**: `redis.yaml` switches to `command:` so it runs `redis-server --requirepass "$REDIS_PASSWORD"` (ephemeral-cache flags preserved); readiness probe authenticates (`redis-cli --no-auth-warning -a …`). Because `command:` bypasses the image entrypoint's privilege drop, a non-root `securityContext` (uid 999) is pinned explicitly.
- **Web + scheduler** get an explicit `REDIS_PASSWORD` secret ref and build `REDIS_URL=redis://:$(REDIS_PASSWORD)@{fullname}-redis:6379/1` via **Kubernetes `$(VAR)` env interpolation** — the credential never appears in a rendered manifest, and no app code changes (settings reads `REDIS_URL` as-is). The scheduler's migrate-check init drops its (unused) `REDIS_URL`.
- **prd `redis.enabled: true`**.

## Secret handling (already done, out-of-band)

`REDIS_PASSWORD` (distinct per env, `token_urlsafe(24)`) was added to `family-pickem/{dev,prd}/envvars` in **AWS Secrets Manager** and force-synced via **ESO**; verified present in both K8s `-envvars` secrets before this deploy (so pods won't fail closed on a missing key).

## Testing

- `check` clean; `makemigrations --check` → none; suite **873 OK**.
- `helm lint` clean; render verified: `--requirepass`, auth'd probe, non-root securityContext, `REDIS_URL` interpolation (web+scheduler), init has no `REDIS_URL`.
- Local review (code-reviewer agent): auth wiring correct; the root-user regression was caught and fixed here.

## Rollout note

Independent Deployments, so a brief old-pod/new-Redis window can occur on rollout; the cache already runs with `IGNORE_EXCEPTIONS: True` (degrades to no-cache, never 500s), and Redis has no other consumers yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)