### PR TITLE
Hotfix: scheduler crashes under uvicorn (SynchronousOnlyOperation)

### DIFF
--- a/pickem/pickem_api/apps.py
+++ b/pickem/pickem_api/apps.py
@@ -48,4 +48,14 @@ class PickemApiConfig(AppConfig):
 
         from . import scheduler
 
-        scheduler.start()
+        # Start in a dedicated thread. Under uvicorn (ASGI) ready() runs with a
+        # running event loop, and scheduler.start() does synchronous DB access
+        # (ScheduledJobConfig.seed_from_pipeline + jobstore cleanup) which Django
+        # forbids from an async context (SynchronousOnlyOperation). A fresh
+        # thread has no running loop, so the sync ORM calls are allowed there.
+        # The BackgroundScheduler it creates runs its jobs in its own threads too.
+        import threading
+
+        threading.Thread(
+            target=scheduler.start, name="scheduler-start", daemon=True
+        ).start()


### PR DESCRIPTION
## Incident

After the 3a uvicorn migration (`0.0.196`), the **prd scheduler pod crash-looped** (`SynchronousOnlyOperation`). Root cause: under uvicorn (ASGI) `apps.ready()` runs with a running event loop, and `scheduler.start()` does synchronous DB access (`ScheduledJobConfig.seed_from_pipeline` + jobstore cleanup), which Django forbids from an async context. Under `runserver` (WSGI) this was only the benign "DB access during app init" warning; under ASGI it's a hard crash. **Web tier was unaffected** (users fine); only the background pipeline was down. Offseason → low impact.

## Fix

Start the scheduler in a dedicated thread from `ready()`. A fresh thread has no running event loop, so Django's async-unsafe guard allows the synchronous ORM calls. The BackgroundScheduler it creates runs its jobs in its own threads too.

## Verification (before/after under real uvicorn, local)

- **Without fix:** `SynchronousOnlyOperation` ×2, scheduler never starts (reproduces prod).
- **With fix:** "APScheduler started", no error.
- Full suite: OK (6 skipped).

## Why tests/dev didn't catch it

The bug is ASGI-runtime-only (the sync test suite can't surface it), and dev was still running a stale `0.0.196-latest` image with the old `runserver` entrypoint at prd-sync time, so the dev-first gate didn't exercise uvicorn. Follow-up: an ASGI smoke check + verifying dev is on the actual new image before treating it as a gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)