### PR TITLE
fix(gitops): restore dev ArgoCD auto-tracking of -latest

### DIFF
--- a/infra/argocd/applications/pickem-dev.yaml
+++ b/infra/argocd/applications/pickem-dev.yaml
@@ -11,7 +11,7 @@ spec:
     # Helm chart source — tracks latest pre-release versions
     - repoURL: https://jimdaga.github.io/family-pickem
       chart: family-pickem
-      targetRevision: "0.0.196-latest"
+      targetRevision: ">=0.0.0-latest"
       helm:
         valueFiles:
           - $values/infra/app/values-dev.yaml


### PR DESCRIPTION
Dev's ArgoCD `pickem-dev` helm `targetRevision` was accidentally changed from the documented auto-tracking range `">=0.0.0-latest"` to a fixed pin `"0.0.196-latest"` in `c693b36` ("chore(gitops): upgrade cluster controllers"). As a result dev stopped rolling forward — it's been stuck on `0.0.196-latest` for ~13h and never received the 3a (uvicorn) or 3b (SSE) `-latest` builds, which broke the dev-first deploy gate.

This restores `">=0.0.0-latest"` so ArgoCD dev resolves to the newest published `-latest` chart (currently `0.0.198-latest`, containing 3a+3b). No prd change (prd targetRevision is bumped per-release by the release workflow's `update_argocd` job, as intended).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application deployment configuration to accept newer compatible chart versions automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->