### PR TITLE
Phase 3c: live points + complete live game state (#138)

### DIFF
--- a/docs/superpowers/plans/2026-08-03-live-updates-phase3c-standings.md
+++ b/docs/superpowers/plans/2026-08-03-live-updates-phase3c-standings.md
@@ -1,0 +1,369 @@
+# Live Updates — Phase 3c: Live Points + Lobby (+ complete live game state) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Live points on the lobby + standings (patched in place; rank/order on reload), via downstream-on-final recompute + a pool-membership-scoped SSE stream; plus complete the live game state on `/scores/` (clock/quarter + per-quarter line scores). Folds in the deferred 3b minors.
+
+**Architecture:** When a game finals, the fast `live_scores_tick` runs the scoped downstream recompute; `update_standings` publishes changed points to a pool-scoped `standings:{pool}:{season}` Redis channel. A new async `/events/standings/` endpoint verifies pool membership (via `sync_to_async`) and streams it. The client patches points by `data-user-id`. Separately, the scores payload/client gain the clock/quarter + per-quarter scores.
+
+**Tech Stack:** Django 5.2 async views + `sync_to_async`, redis-py / `redis.asyncio`, uvicorn/ASGI, APScheduler, vanilla JS `EventSource`.
+
+## Global Constraints
+
+- Python `>=3.12`, Django `5.2.16`; deps already present (`redis`, `django-redis`, `uvicorn`). Tests: `--settings=pickem.test_settings`, unittest discovery, `TestCase`/`SimpleTestCase` classes only.
+- **No sync ORM in any async view/generator** (the 3a lesson that crashed prod): the SSE membership check and season lookup MUST go through `asgiref.sync.sync_to_async`; use `redis.asyncio` for the subscription. Reviewers must grep the async module for `.objects`/`models.`.
+- Standings are **pool-scoped and not public**: the SSE endpoint must stream `standings:{pool}:{season}` ONLY to members of that pool (`FamilyMembership` user→family→pool). Non-members → 403. Cover both directions with tests.
+- `update_standings` is **season-scoped** (`userSeasonPoints.total_points`); channel is `standings:{pool}:{season}` (no week). Publish is best-effort (never breaks the pipeline), like 3b.
+- Reuse 3b machinery: generalize `live_events` to `publish_event(channel, payload)`; reuse the `_event_stream(channel)` async generator (keepalive, graceful Redis-error end, guarded cleanup) for the standings endpoint.
+- Client: no row reordering, no live rank number (reload only). No `?v=` cache-buster on `{% static %}`. Rebuild `tailwind.css` only if utility classes are added (they won't be).
+- GitOps: dev auto-tracks `-latest` again (fixed 2026-08-03). Verify dev is actually on the new image (image tag + a runtime signal) before the prd release — do NOT merge+release back-to-back for this runtime-heavy change.
+
+---
+
+### Task 1: Generalize live_events + standings/scores payloads
+
+**Files:**
+- Modify: `pickem/pickem_api/live_events.py`
+- Modify: `pickem/pickem_api/tests/test_live_events.py`
+
+**Interfaces:**
+- Produces: `publish_event(channel, payload)` (generalized best-effort publisher); `standings_channel(pool_id, season)` → `f"standings:{pool_id}:{season}"`; `standings_event_payload(row, week)` → `{user_id, total_points, week, week_points, current_rank}`; `SCORE_TRIGGER_FIELDS` (extends `LIVE_SCORE_FIELDS` with the per-quarter period fields); `score_event_payload` extended with period arrays. `publish_score_event` stays as a thin wrapper over `publish_event` for back-compat with 3b callers.
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `pickem/pickem_api/tests/test_live_events.py`:
+
+```python
+class StandingsEventTests(SimpleTestCase):
+    def test_standings_channel(self):
+        self.assertEqual(live_events.standings_channel(7, 2627), "standings:7:2627")
+
+    def test_standings_payload(self):
+        from unittest import mock
+        row = mock.Mock(userID="u1", total_points=42, current_rank=2)
+        setattr(row, "week_3_points", 5)
+        p = live_events.standings_event_payload(row, 3)
+        self.assertEqual(p["user_id"], "u1")
+        self.assertEqual(p["total_points"], 42)
+        self.assertEqual(p["week"], 3)
+        self.assertEqual(p["week_points"], 5)
+
+
+class ScorePayloadPeriodsTests(SimpleTestCase):
+    def test_score_payload_includes_periods_and_status_title(self):
+        from unittest import mock
+        g = mock.Mock(id=1, homeTeamScore=7, awayTeamScore=0, statusType="inprogress",
+                      statusTitle="5:00 - 2nd Quarter", gameWinner="",
+                      homeTeamPeriod1=7, homeTeamPeriod2=0, homeTeamPeriod3=0,
+                      homeTeamPeriod4=0, homeTeamPeriodOT=0,
+                      awayTeamPeriod1=0, awayTeamPeriod2=0, awayTeamPeriod3=0,
+                      awayTeamPeriod4=0, awayTeamPeriodOT=0)
+        p = live_events.score_event_payload(g)
+        self.assertEqual(p["status_title"], "5:00 - 2nd Quarter")
+        self.assertEqual(p["home_periods"], [7, 0, 0, 0, 0])
+        self.assertEqual(p["away_periods"], [0, 0, 0, 0, 0])
+```
+
+- [ ] **Step 2: Run — verify fail**
+
+```bash
+cd pickem && uv run python manage.py test pickem_api.tests.test_live_events --settings=pickem.test_settings -v 2
+```
+Expected: FAIL (missing `standings_channel`/`standings_event_payload`/period keys).
+
+- [ ] **Step 3: Implement in `live_events.py`**
+
+Generalize the publisher and add the standings helpers + period fields:
+
+```python
+def publish_event(channel, payload):
+    """Best-effort publish of one event to a Redis channel. Never raises."""
+    try:
+        client = _redis_client()
+        if client is None:
+            return
+        client.publish(channel, json.dumps(payload))
+    except Exception:
+        logger.warning("live event publish failed", exc_info=True)
+
+
+def publish_score_event(season, week, payload):
+    publish_event(scores_channel(season, week), payload)
+
+
+# Period fields also trigger a scores publish (clock/quarter live updates).
+_PERIOD_FIELDS = (
+    "homeTeamPeriod1", "homeTeamPeriod2", "homeTeamPeriod3", "homeTeamPeriod4",
+    "homeTeamPeriodOT", "awayTeamPeriod1", "awayTeamPeriod2", "awayTeamPeriod3",
+    "awayTeamPeriod4", "awayTeamPeriodOT",
+)
+SCORE_TRIGGER_FIELDS = LIVE_SCORE_FIELDS + _PERIOD_FIELDS
+
+
+def standings_channel(pool_id, season):
+    return f"standings:{pool_id}:{season}"
+
+
+def standings_event_payload(row, week):
+    return {
+        "user_id": row.userID,
+        "total_points": row.total_points,
+        "week": week,
+        "week_points": getattr(row, f"week_{week}_points", None),
+        "current_rank": getattr(row, "current_rank", None),
+    }
+```
+
+Extend `score_event_payload` to add:
+
+```python
+        "home_periods": [game.homeTeamPeriod1, game.homeTeamPeriod2,
+                         game.homeTeamPeriod3, game.homeTeamPeriod4,
+                         game.homeTeamPeriodOT],
+        "away_periods": [game.awayTeamPeriod1, game.awayTeamPeriod2,
+                         game.awayTeamPeriod3, game.awayTeamPeriod4,
+                         game.awayTeamPeriodOT],
+```
+
+- [ ] **Step 4: Run — verify pass** (all `test_live_events` tests).
+- [ ] **Step 5: Commit**
+
+```bash
+git add pickem/pickem_api/live_events.py pickem/pickem_api/tests/test_live_events.py
+git commit -m "feat(live): generalize publisher; standings channel/payload; score periods (#138)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: update_games publishes clock/quarter changes
+
+Extend the scores change-detection to fire on `statusTitle`/period changes (not just totals) so the clock/quarter ticks live.
+
+**Files:**
+- Modify: `pickem/pickem_api/management/commands/update_games.py`
+- Modify: `pickem/pickem_api/tests/test_update_games_publish.py`
+
+- [ ] **Step 1:** In `update_games.py`, change the imported/used trigger set from `LIVE_SCORE_FIELDS` to `SCORE_TRIGGER_FIELDS` in `maybe_publish_game_change` and in the `previous_by_id` `.values(...)` pre-fetch (so a clock/quarter change is detected). Keep the payload = `score_event_payload` (now with periods).
+- [ ] **Step 2:** Add a test: a game whose only change is `statusTitle` (clock tick) publishes; a fully-unchanged game does not. Run the `test_update_games_publish` module.
+- [ ] **Step 3:** Full suite green.
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -am "feat(live): publish clock/quarter (statusTitle+period) changes from update_games (#138)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: update_standings publish-on-write
+
+**Files:**
+- Modify: `pickem/pickem_api/management/commands/update_standings.py`
+- Test: `pickem/pickem_api/tests/test_update_standings_publish.py`
+
+- [ ] **Step 1:** Write a failing test: a member whose `total_points` changed publishes to `standings:{pool}:{season}`; unchanged does not. (Test a helper `maybe_publish_standings_change(before_total, row, week)` mirroring `maybe_publish_game_change`, mocking `publish_event`.)
+- [ ] **Step 2:** Run — verify fail.
+- [ ] **Step 3:** Implement: at the `get_or_create` in `handle()`, capture the pre-save `total_points` (the row is fetched/created before recompute; capture `row.total_points` before mutation). After `row.save()`, call `maybe_publish_standings_change(old_total, row, current_week)` which publishes `standings_event_payload(row, current_week)` to `standings_channel(row.pool_id, season)` when `total_points` changed. Compute `current_week` once (from `get_season`-adjacent week lookup or `GameWeeks` for today; if unavailable, publish with the season-total only and `week=None`). Best-effort (never breaks the recompute).
+- [ ] **Step 4:** Run — verify pass; full suite green.
+- [ ] **Step 5: Commit**
+
+```bash
+git add pickem/pickem_api/management/commands/update_standings.py pickem/pickem_api/tests/test_update_standings_publish.py
+git commit -m "feat(live): publish changed standings points from update_standings (#138)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Downstream-on-final in the fast tick
+
+**Files:**
+- Modify: `pickem/pickem_api/scheduler.py`
+- Modify: `pickem/pickem_api/tests/test_live_window.py`
+
+**Interfaces:**
+- Produces: `scheduler.finished_unscored_exists()` (any current-season game `finished` with `gameScored=False`); `run_live_scores_tick` also runs the scoped downstream when that's true.
+
+- [ ] **Step 1:** Write failing tests: `finished_unscored_exists()` true iff a finished+unscored game exists; `run_live_scores_tick`, after `update_games`, runs the downstream chain (mock `run_job_once`) exactly once when `finished_unscored_exists()` and skips it otherwise. (Keep the existing update_games overlap guard behavior.)
+- [ ] **Step 2:** Run — verify fail.
+- [ ] **Step 3:** Implement in `scheduler.py`:
+
+```python
+def finished_unscored_exists():
+    from pickem.utils import get_season
+    from pickem_api.models import GamesAndScores
+    return GamesAndScores.objects.filter(
+        gameseason=get_season(), statusType="finished", gameScored=False
+    ).exists()
+```
+
+In `run_live_scores_tick`, after the `update_games` run, add:
+
+```python
+    if finished_unscored_exists():
+        for job in ("update_picks", "update_standings", "update_rankings", "update_stats"):
+            if _update_games_running():  # never overlap update_games step (n/a here) — keep guard pattern
+                pass
+            run_job_once(job)
+```
+
+(Confirm `gameScored` is the field `update_picks` flips once a finished game is scored — verify in `update_picks`/models before relying on it; adjust the flag name if different.)
+
+- [ ] **Step 4:** Run — verify pass; full suite green.
+- [ ] **Step 5: Commit**
+
+```bash
+git add pickem/pickem_api/scheduler.py pickem/pickem_api/tests/test_live_window.py
+git commit -m "feat(live): downstream-on-final recompute in the fast tick (#138)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Pool-membership auth helper + /events/standings/ endpoint
+
+**Files:**
+- Modify: `pickem/pickem_homepage/live_views.py`
+- Modify: `pickem/pickem_homepage/urls.py`
+- Modify: `pickem/pickem_homepage/tests.py` (SSE tests live here — module, not package)
+
+**Interfaces:**
+- Produces: route `live_standings_events` at `/events/standings/`; sync helper `_resolve_pool_for_member(user, family_slug, pool_slug)` → `(pool_id, season)` or `None`.
+
+- [ ] **Step 1:** Write failing tests in `tests.py`: `/events/standings/` reverses; a non-member (authenticated, not in the pool's family) gets 403; anonymous is redirected (middleware). Use existing test factories/fixtures for a family+pool+membership if present.
+- [ ] **Step 2:** Run — verify fail.
+- [ ] **Step 3:** Implement. Add a sync helper (called via `sync_to_async`):
+
+```python
+def _resolve_pool_for_member(user, family_slug, pool_slug):
+    """(pool_id, season) if `user` is a member of the pool, else None. Sync — call
+    via sync_to_async from the async view."""
+    from pickem_api.models import FamilyMembership, Pool
+    pool = (
+        Pool.objects.filter(family__slug=family_slug, slug=pool_slug)
+        .values("id", "season", "family_id")
+        .first()
+    )
+    if not pool:
+        return None
+    if not FamilyMembership.objects.filter(
+        user=user, family_id=pool["family_id"]
+    ).exists():
+        return None
+    return pool["id"], pool["season"]
+```
+
+Async view:
+
+```python
+async def live_standings_events(request):
+    family_slug = request.GET.get("family", "").strip()
+    pool_slug = request.GET.get("pool", "").strip()
+    if not family_slug or not pool_slug:
+        return HttpResponseBadRequest("family and pool required")
+    resolved = await sync_to_async(_resolve_pool_for_member)(
+        request.user, family_slug, pool_slug
+    )
+    if resolved is None:
+        from django.http import HttpResponseForbidden
+        return HttpResponseForbidden("not a member of this pool")
+    pool_id, season = resolved
+    from pickem_api.live_events import standings_channel
+    resp = StreamingHttpResponse(
+        _event_stream(standings_channel(pool_id, season)),
+        content_type="text/event-stream",
+    )
+    resp["Cache-Control"] = "no-cache"
+    resp["X-Accel-Buffering"] = "no"
+    return resp
+```
+
+Add the route to `urls.py`:
+
+```python
+    path("events/standings/", live_views.live_standings_events, name="live_standings_events"),
+```
+
+- [ ] **Step 4:** Run — verify pass (member/non-member/anon). Confirm no sync ORM in the async view (grep `live_views.py` for `.objects` outside the sync helper).
+- [ ] **Step 5:** Local smoke (optional, if DB available): boot uvicorn, hit `/events/standings/` as a member/non-member.
+- [ ] **Step 6: Commit**
+
+```bash
+git add pickem/pickem_homepage/live_views.py pickem/pickem_homepage/urls.py pickem/pickem_homepage/tests.py
+git commit -m "feat(live): pool-membership-scoped /events/standings/ SSE endpoint (#138)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Client — live points + complete live game state + fold-in 3b minors
+
+**Files:**
+- Modify: `pickem/pickem_homepage/templates/pickem/family_pool_home.html` (lobby week-points-summary rows + "Your rank" tile area)
+- Modify: `pickem/pickem_homepage/templates/pickem/standings.html` (standings rows)
+- Modify: `pickem/pickem_homepage/templates/pickem/scores.html` (extend `applyScoreEvent`; fold-in minors)
+
+- [ ] **Step 1: Standings data attributes.** On the lobby `week_points_summary` rows add `data-user-id="{{ row.points.userID }}"` and `data-user-week-points` on the `{{ row.week_points }}` element. On `standings.html` rows add `data-user-id` + `data-user-total-points` on the points cell. (Read the actual templates for the exact variables — `row.points.userID`, `row.week_points`, etc.)
+
+- [ ] **Step 2: Standings EventSource.** On both templates, add an `EventSource('/events/standings/?family=<fslug>&pool=<pslug>&week=<n>')` (expose slugs+week via `data-*`), with a handler that patches `[data-user-id="..."] [data-user-week-points]` / `[data-user-total-points]` textContent from `{user_id, total_points, week_points}`. Reuse the 3b client pattern: feature-check, `sseErrorCount`-based poll fallback (or just silent no-op if no poll exists on that page), close on give-up. Do NOT reorder rows / touch rank.
+
+- [ ] **Step 3: Complete live game state in `scores.html` `applyScoreEvent`.** For non-status-change events, in addition to totals, patch: the status/clock text (add `data-status-title` to the `{{ game.statusTitle }}` header span) from `d.status_title`, and the per-quarter `.quarter-score` cells (add `data-home-period="1..4/OT"` / `data-away-period` markers) from `d.home_periods`/`d.away_periods`.
+
+- [ ] **Step 4: Fold in the deferred 3b minors** (in `scores.html`): (a) guard `filterGames` so it doesn't `startLiveUpdates()` when an SSE stream is healthy (`sseSource` non-null); (b) the rare `notstarted→finished` direct-jump — in the status-change branch, if `d.status !== 'inprogress'` and no other live game exists, still refresh (e.g. temporarily force the gate). Keep it minimal.
+
+- [ ] **Step 5:** `cd pickem && uv run python manage.py check --settings=pickem.test_settings`; full suite green; no `?v=` cache-buster; no Tailwind rebuild.
+
+- [ ] **Step 6:** Manual (local, if feasible): with uvicorn+Redis, publish a `standings:{pool}:{season}` event and confirm a lobby row's points patch; publish a scores event with a new `status_title`/periods and confirm the clock + quarter cells update.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pickem/pickem_homepage/templates/pickem/family_pool_home.html pickem/pickem_homepage/templates/pickem/standings.html pickem/pickem_homepage/templates/pickem/scores.html
+git commit -m "feat(live): live points on lobby/standings + live clock/quarter; fold in 3b minors (#138)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Add the missing SSE Redis-error-branch test (deferred 3b minor)
+
+**Files:**
+- Modify: `pickem/pickem_homepage/tests.py`
+
+- [ ] **Step 1:** Add a test that drives `_event_stream` with a fake pubsub whose `subscribe`/`get_message` raises a redis error, asserting the generator ends gracefully (no exception propagates; the `except Exception` branch runs) — mirroring the existing `SseStreamShapeTests` fake-pubsub approach.
+- [ ] **Step 2:** Run — verify pass; full suite green.
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -am "test(live): cover SSE _event_stream graceful end on Redis error (#138)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Deploy verification (dev → prd)
+
+- [ ] **Step 1 (dev, post-merge):** After dev rolls to the new `-latest` (confirm the image tag advanced + `reverse('live_standings_events')` resolves), verify: `/events/standings/` requires membership (403 for a non-member; stream for a member), a `standings:{pool}:{season}` pub/sub round-trip works on the authed Redis, and the scheduler stays healthy (recent `JobRun`, 0 restarts). Confirm dev is genuinely on the new image before proceeding (3a lesson).
+- [ ] **Step 2 (prd, post-release):** Repeat against `pickem-prd`; confirm scheduler healthy (no crashloop), `/events/standings/` membership-scoped, live points patch a lobby row and the clock/quarter tick on `/scores/` in a browser during (or via a published test event) a live game.
+
+---
+
+## Self-Review
+
+**Spec coverage:** downstream-on-final (Task 4); standings publish-on-write (Tasks 1+3); pool-scoped SSE auth (Task 5); client live points (Task 6); complete live game state clock/quarter+periods (Tasks 1,2,6); fold-in 3b minors (Tasks 6,7); dev→prd verify (Task 8). ✓
+
+**Placeholder scan:** Task 4's `gameScored` field name and Task 3's `current_week` derivation are flagged to verify against the code during implementation (not left vague — the verification step is explicit). All other steps carry concrete code/commands.
+
+**Type/name consistency:** `publish_event`/`standings_channel`/`standings_event_payload`/`SCORE_TRIGGER_FIELDS` defined in Task 1 and consumed in Tasks 2,3,5; channel `standings:{pool}:{season}` identical in publisher (Task 3) and subscriber (Task 5); route name `live_standings_events` matches the test and client URL; payload keys (`user_id`/`total_points`/`week_points`; `status_title`/`home_periods`/`away_periods`) consistent between payload producers (Task 1) and the client (Task 6).
+
+**Async-safety (3a lesson):** Task 5's membership check + season lookup go through `sync_to_async`; the async view uses `redis.asyncio` via the reused `_event_stream`. Reviewer must confirm no sync ORM leaks into `live_views.py`'s async paths.
+
+**Risk:** pool-scoped auth correctness — Task 5 tests both member (stream) and non-member (403) directions.

--- a/docs/superpowers/specs/2026-08-03-live-updates-phase3c-standings.md
+++ b/docs/superpowers/specs/2026-08-03-live-updates-phase3c-standings.md
@@ -1,0 +1,91 @@
+# Live Updates — Phase 3c: Live Points / W-L + Lobby — Design
+
+**Date:** 2026-08-03
+**Status:** Approved (design); pending spec review
+**Related issues:** #138
+**Parent:** `docs/superpowers/specs/2026-08-02-live-updates-design.md` (Phase 3)
+**Depends on:** 3a (uvicorn, 0.0.196/0.0.197), 3b (SSE scores, 0.0.198), Redis w/ auth.
+
+## Goal
+
+Make each player's **points and wins/losses** update live (no reload) on the
+lobby and standings views as games settle — completing the live experience for
+scores (3b) + points/W-L (3c). **Scope decision:** leaderboard *ordering* updates
+on the next natural page load, not via live row animation (points/W-L numbers
+patch in place). Live rank-reordering is a deferred fast-follow.
+
+## Design
+
+### A. Downstream-on-final (scheduler)
+Points/W-L change only when a game settles. Extend the fast `live_scores_tick`:
+after `update_games`, if the current week has any **finished-but-unscored** game
+(`GamesAndScores.statusType == "finished"` with `gameScored == False`), run the
+scoped downstream once — `update_picks → update_standings → update_rankings →
+update_stats` (pool-scoped where the command supports `--pool`). This catches a
+final within ~12s instead of waiting for the 60s pipeline; it's idempotent
+(scoring flips `gameScored`, so subsequent ticks skip) and only fires on real
+transitions.
+
+### B. Publish-on-write (standings)
+Add best-effort publish to `update_standings` (mirroring 3b's `update_games`):
+after recomputing a pool member's row, if points/wins/losses changed, publish a
+compact delta to the **pool-scoped** channel `standings:{pool}:{season}:{week}` —
+`{user_id, points, wins, losses, rank}` (rank included for a future fast-follow;
+the 3c client ignores it). Only changed rows publish. Reuse `live_events.py`
+(add `standings_channel()` + `standings_event_payload()` + reuse
+`publish_score_event`'s best-effort publisher, generalized to `publish_event`).
+
+### C. SSE endpoint — pool-scoped auth (the key new piece)
+Scores are public; standings are not. Add `GET /events/standings/?pool=<slug>&week=<n>`
+(async, uvicorn). It:
+- Resolves the current season and the pool from `<slug>`, and **verifies the
+  requesting user is a member of that pool** via `FamilyMembership` (user → family
+  → pool) — all through `sync_to_async` (no sync ORM in the async path, per the
+  3a lesson). Non-members get 403; anonymous is already blocked by
+  `RequireLoginForInternalPagesMiddleware`.
+- Subscribes to `standings:{pool}:{season}:{week}` and streams like 3b (reuse the
+  generalized `_event_stream(channel)` — keepalive, graceful Redis-error end,
+  guarded cleanup).
+- The page keeps its own scores `EventSource` (3b) for game scores; standings is
+  a second, pool-scoped stream. Two lightweight connections per page is fine at
+  this scale (per-connection subscribe, per 3b's decision).
+
+### D. Client
+On the lobby (`home.html` / `family_pool_home.html`) and standings page, add an
+`EventSource('/events/standings/?pool=<slug>&week=<n>')` that patches each
+player's points and W-L **in place** by `data-user-id` (add `data-user-id` +
+`data-user-points` / `data-user-record` attributes to the standings rows). Reuse
+the 3b client pattern (feature-check, patch, poll fallback after repeated errors,
+close on give-up). Do NOT reorder rows. Expose the pool slug + week to JS via
+data attributes.
+
+### E. Fold in deferred 3b minors
+While in these files: (1) guard `filterGames` so it doesn't start the 30s poll
+while an SSE stream is healthy; (2) add the missing unit test for the SSE
+Redis-error branch (`_event_stream` ending gracefully on a subscribe/connection
+error); (3) the rare `notstarted→finished` direct-jump card refresh.
+
+## Testing / verification
+- Unit: standings change-detection + payload; pool-membership auth helper
+  (member → allowed, non-member → denied) via the sync helper; downstream-on-final
+  trigger (finished-unscored → runs recompute; none → skips).
+- Async: `/events/standings/` requires membership (403 for non-member, stream for
+  member); reuses the 3b stream-shape coverage.
+- Full suite green.
+- Dev→prd (gated, dev verified first per the 3a/dev-autotrack lesson): standings
+  route reachable + membership-scoped, `standings:` pub/sub round-trip on authed
+  Redis, and a settled game's points/W-L patching a lobby row live in a browser.
+
+## Risks
+- **Pool-scoped auth correctness** — a membership-check bug could leak another
+  family's standings or wrongly deny a member. Cover both directions with tests.
+- **Downstream cost during dense slates** — the scoped recompute on each final is
+  heavier than a score publish; it's gated on finished-unscored and idempotent,
+  but confirm it doesn't pile up when several games final near-simultaneously
+  (the `update_games` overlap guard from 3b plus `gameScored` idempotency should
+  contain it).
+- Async-safety: all DB access in the async view via `sync_to_async` (3a lesson).
+
+## Out of scope
+- Live leaderboard **row reordering** / live rank number (deferred fast-follow).
+- Per-replica broadcaster (still deferred; per-connection is fine).

--- a/docs/superpowers/specs/2026-08-03-live-updates-phase3c-standings.md
+++ b/docs/superpowers/specs/2026-08-03-live-updates-phase3c-standings.md
@@ -64,6 +64,22 @@ player's **points in place** by `data-user-id` (add `data-user-id` +
 NOT reorder rows or change rank numbers (those update on reload). Expose the pool
 slug + week to JS via data attributes.
 
+### F. Complete the live game state on /scores/ (clock/quarter + per-quarter)
+3b made team **totals** and coarse **status** (notstarted→inprogress→final) live,
+but not the ticking clock/quarter (`statusTitle`) or the per-quarter line scores —
+those only refresh on a status transition or reload. Close that gap:
+- **Payload:** `score_event_payload` already includes `status_title`; add the
+  period arrays (`homeTeamPeriod1..4/OT`, `awayTeamPeriod1..4/OT`). Add the period
+  fields (and `statusTitle`, already present) to the change-detection trigger so a
+  clock/quarter change publishes even without a total-score change.
+- **Client:** in `applyScoreEvent`, on every (non-transition) event also patch the
+  card's status/clock text (add `data-status-title` to the `{{ game.statusTitle }}`
+  header span) and the per-quarter `.quarter-score` cells (add `data-period`
+  markers, e.g. `data-home-period="1"`). So the game clock and quarter scores tick
+  live, not just the totals.
+- This is the scores surface (`scores.html` / `live_events.py` / `update_games`),
+  bundled into 3c's shipment.
+
 ### E. Fold in deferred 3b minors
 While in these files: (1) guard `filterGames` so it doesn't start the 30s poll
 while an SSE stream is healthy; (2) add the missing unit test for the SSE

--- a/docs/superpowers/specs/2026-08-03-live-updates-phase3c-standings.md
+++ b/docs/superpowers/specs/2026-08-03-live-updates-phase3c-standings.md
@@ -40,13 +40,15 @@ points.) Reuse `live_events.py` — add `standings_channel(pool, season)` +
 a `publish_event(channel, payload)` used by both scores and standings.
 
 ### C. SSE endpoint — pool-scoped auth (the key new piece)
-Scores are public; standings are not. Add `GET /events/standings/?pool=<slug>&week=<n>`
-(async, uvicorn). It:
-- Resolves the current season and the pool from `<slug>`, and **verifies the
-  requesting user is a member of that pool** via `FamilyMembership` (user → family
-  → pool) — all through `sync_to_async` (no sync ORM in the async path, per the
-  3a lesson). Non-members get 403; anonymous is already blocked by
-  `RequireLoginForInternalPagesMiddleware`.
+Scores are public; standings are not. Add `GET /events/standings/?family=<fslug>&pool=<pslug>`
+(async, uvicorn). `family` is required (a pool slug is only unique within a
+family, so `family` disambiguates it); `week` is accepted but currently unused
+by the endpoint. It:
+- Resolves the current season and the pool from `<fslug>`/`<pslug>`, and
+  **verifies the requesting user is a member of that pool** via
+  `FamilyMembership` (user → family → pool) — all through `sync_to_async` (no
+  sync ORM in the async path, per the 3a lesson). Non-members get 403;
+  anonymous is already blocked by `RequireLoginForInternalPagesMiddleware`.
 - Subscribes to `standings:{pool}:{season}` and streams like 3b (reuse the
   generalized `_event_stream(channel)` — keepalive, graceful Redis-error end,
   guarded cleanup).

--- a/docs/superpowers/specs/2026-08-03-live-updates-phase3c-standings.md
+++ b/docs/superpowers/specs/2026-08-03-live-updates-phase3c-standings.md
@@ -1,4 +1,4 @@
-# Live Updates — Phase 3c: Live Points / W-L + Lobby — Design
+# Live Updates — Phase 3c: Live Points + Lobby — Design
 
 **Date:** 2026-08-03
 **Status:** Approved (design); pending spec review
@@ -19,7 +19,7 @@ separate stats page, out of scope.) Live rank/reorder is a deferred fast-follow.
 ## Design
 
 ### A. Downstream-on-final (scheduler)
-Points/W-L change only when a game settles. Extend the fast `live_scores_tick`:
+Points change only when a game settles. Extend the fast `live_scores_tick`:
 after `update_games`, if the current week has any **finished-but-unscored** game
 (`GamesAndScores.statusType == "finished"` with `gameScored == False`), run the
 scoped downstream once — `update_picks → update_standings → update_rankings →
@@ -79,7 +79,7 @@ error); (3) the rare `notstarted→finished` direct-jump card refresh.
 - Full suite green.
 - Dev→prd (gated, dev verified first per the 3a/dev-autotrack lesson): standings
   route reachable + membership-scoped, `standings:` pub/sub round-trip on authed
-  Redis, and a settled game's points/W-L patching a lobby row live in a browser.
+  Redis, and a settled game's points patching a lobby row live in a browser.
 
 ## Risks
 - **Pool-scoped auth correctness** — a membership-check bug could leak another

--- a/docs/superpowers/specs/2026-08-03-live-updates-phase3c-standings.md
+++ b/docs/superpowers/specs/2026-08-03-live-updates-phase3c-standings.md
@@ -58,7 +58,7 @@ by the endpoint. It:
 
 ### D. Client
 On the lobby (`family_pool_home.html`) and the standings page, add an
-`EventSource('/events/standings/?pool=<slug>&week=<n>')` that patches each
+`EventSource('/events/standings/?family=<fslug>&pool=<pslug>')` that patches each
 player's **points in place** by `data-user-id` (add `data-user-id` +
 `data-user-week-points` on the week-points-summary rows, and
 `data-user-total-points` on the standings-page rows). Reuse the 3b client pattern

--- a/docs/superpowers/specs/2026-08-03-live-updates-phase3c-standings.md
+++ b/docs/superpowers/specs/2026-08-03-live-updates-phase3c-standings.md
@@ -8,11 +8,13 @@
 
 ## Goal
 
-Make each player's **points and wins/losses** update live (no reload) on the
-lobby and standings views as games settle — completing the live experience for
-scores (3b) + points/W-L (3c). **Scope decision:** leaderboard *ordering* updates
-on the next natural page load, not via live row animation (points/W-L numbers
-patch in place). Live rank-reordering is a deferred fast-follow.
+Make each player's **points** (this week's `week_N_points` and season
+`total_points`) update live (no reload) on the lobby and standings views as games
+settle — completing the live experience for scores (3b) + points (3c). **Scope
+(confirmed):** points patch in place; the leaderboard *order* and the *rank
+number* update on the next natural page load, not live. (There is no W/L record
+in this app — standings metrics are points + rank; pick-accuracy stats are a
+separate stats page, out of scope.) Live rank/reorder is a deferred fast-follow.
 
 ## Design
 
@@ -28,12 +30,14 @@ transitions.
 
 ### B. Publish-on-write (standings)
 Add best-effort publish to `update_standings` (mirroring 3b's `update_games`):
-after recomputing a pool member's row, if points/wins/losses changed, publish a
-compact delta to the **pool-scoped** channel `standings:{pool}:{season}:{week}` —
-`{user_id, points, wins, losses, rank}` (rank included for a future fast-follow;
-the 3c client ignores it). Only changed rows publish. Reuse `live_events.py`
-(add `standings_channel()` + `standings_event_payload()` + reuse
-`publish_score_event`'s best-effort publisher, generalized to `publish_event`).
+after recomputing a pool member's `userSeasonPoints` row, if `total_points` (or
+the current week's `week_N_points`) changed, publish a compact delta to the
+**pool-scoped, season-scoped** channel `standings:{pool}:{season}` —
+`{user_id, total_points, week, week_points, current_rank}` for changed rows only.
+(`current_rank` is included for a future fast-follow; the 3c client patches only
+points.) Reuse `live_events.py` — add `standings_channel(pool, season)` +
+`standings_event_payload(row, week)`, and generalize the best-effort publisher to
+a `publish_event(channel, payload)` used by both scores and standings.
 
 ### C. SSE endpoint — pool-scoped auth (the key new piece)
 Scores are public; standings are not. Add `GET /events/standings/?pool=<slug>&week=<n>`
@@ -43,7 +47,7 @@ Scores are public; standings are not. Add `GET /events/standings/?pool=<slug>&we
   → pool) — all through `sync_to_async` (no sync ORM in the async path, per the
   3a lesson). Non-members get 403; anonymous is already blocked by
   `RequireLoginForInternalPagesMiddleware`.
-- Subscribes to `standings:{pool}:{season}:{week}` and streams like 3b (reuse the
+- Subscribes to `standings:{pool}:{season}` and streams like 3b (reuse the
   generalized `_event_stream(channel)` — keepalive, graceful Redis-error end,
   guarded cleanup).
 - The page keeps its own scores `EventSource` (3b) for game scores; standings is
@@ -51,13 +55,14 @@ Scores are public; standings are not. Add `GET /events/standings/?pool=<slug>&we
   this scale (per-connection subscribe, per 3b's decision).
 
 ### D. Client
-On the lobby (`home.html` / `family_pool_home.html`) and standings page, add an
+On the lobby (`family_pool_home.html`) and the standings page, add an
 `EventSource('/events/standings/?pool=<slug>&week=<n>')` that patches each
-player's points and W-L **in place** by `data-user-id` (add `data-user-id` +
-`data-user-points` / `data-user-record` attributes to the standings rows). Reuse
-the 3b client pattern (feature-check, patch, poll fallback after repeated errors,
-close on give-up). Do NOT reorder rows. Expose the pool slug + week to JS via
-data attributes.
+player's **points in place** by `data-user-id` (add `data-user-id` +
+`data-user-week-points` on the week-points-summary rows, and
+`data-user-total-points` on the standings-page rows). Reuse the 3b client pattern
+(feature-check, patch, poll fallback after repeated errors, close on give-up). Do
+NOT reorder rows or change rank numbers (those update on reload). Expose the pool
+slug + week to JS via data attributes.
 
 ### E. Fold in deferred 3b minors
 While in these files: (1) guard `filterGames` so it doesn't start the 30s poll

--- a/pickem/pickem_api/live_events.py
+++ b/pickem/pickem_api/live_events.py
@@ -36,6 +36,12 @@ def score_event_payload(game):
         "status": game.statusType,
         "status_title": game.statusTitle,
         "winner": game.gameWinner,
+        "home_periods": [game.homeTeamPeriod1, game.homeTeamPeriod2,
+                         game.homeTeamPeriod3, game.homeTeamPeriod4,
+                         game.homeTeamPeriodOT],
+        "away_periods": [game.awayTeamPeriod1, game.awayTeamPeriod2,
+                         game.awayTeamPeriod3, game.awayTeamPeriod4,
+                         game.awayTeamPeriodOT],
     }
 
 
@@ -49,12 +55,42 @@ def _redis_client():
     return redis.from_url(url)
 
 
-def publish_score_event(season, week, payload):
-    """Best-effort publish of one score change. Never raises."""
+def publish_event(channel, payload):
+    """Best-effort publish of one event to a Redis channel. Never raises."""
     try:
         client = _redis_client()
         if client is None:
             return
-        client.publish(scores_channel(season, week), json.dumps(payload))
+        client.publish(channel, json.dumps(payload))
     except Exception:
-        logger.warning("live score publish failed", exc_info=True)
+        logger.warning("live event publish failed", exc_info=True)
+
+
+def publish_score_event(season, week, payload):
+    """Best-effort publish of one score change. Never raises."""
+    publish_event(scores_channel(season, week), payload)
+
+
+# Period fields also trigger a scores publish (clock/quarter live updates).
+_PERIOD_FIELDS = (
+    "homeTeamPeriod1", "homeTeamPeriod2", "homeTeamPeriod3", "homeTeamPeriod4",
+    "homeTeamPeriodOT", "awayTeamPeriod1", "awayTeamPeriod2", "awayTeamPeriod3",
+    "awayTeamPeriod4", "awayTeamPeriodOT",
+)
+SCORE_TRIGGER_FIELDS = LIVE_SCORE_FIELDS + _PERIOD_FIELDS
+
+
+def standings_channel(pool_id, season):
+    """Redis pub/sub channel for a pool+season's live standings."""
+    return f"standings:{pool_id}:{season}"
+
+
+def standings_event_payload(row, week):
+    """Compact JSON-serializable dict of a standings row's live fields."""
+    return {
+        "user_id": row.userID,
+        "total_points": row.total_points,
+        "week": week,
+        "week_points": getattr(row, f"week_{week}_points", None),
+        "current_rank": getattr(row, "current_rank", None),
+    }

--- a/pickem/pickem_api/management/commands/update_games.py
+++ b/pickem/pickem_api/management/commands/update_games.py
@@ -18,7 +18,7 @@ from django.utils.dateparse import parse_datetime
 
 from pickem.utils import get_season
 from pickem_api.live_events import (
-    LIVE_SCORE_FIELDS,
+    SCORE_TRIGGER_FIELDS,
     publish_score_event,
     score_event_payload,
 )
@@ -306,14 +306,16 @@ def fetch_scoreboard(week, game_year):
 
 
 def maybe_publish_game_change(before, after):
-    """Publish a live score event if any LIVE_SCORE_FIELD changed (or new game).
+    """Publish a live score event if any SCORE_TRIGGER_FIELD changed (or new game).
 
-    ``before`` is a dict of the row's LIVE_SCORE_FIELDS prior to the upsert, or
-    None if the row was just created. ``after`` is the saved GamesAndScores.
+    ``before`` is a dict of the row's SCORE_TRIGGER_FIELDS prior to the upsert, or
+    None if the row was just created. ``after`` is the saved GamesAndScores. The
+    trigger set includes statusTitle (clock/quarter) and the per-quarter period
+    fields, so the on-screen clock and line scores update live too, not just totals.
     """
     if before is not None:
         changed = any(
-            before.get(f) != getattr(after, f) for f in LIVE_SCORE_FIELDS
+            before.get(f) != getattr(after, f) for f in SCORE_TRIGGER_FIELDS
         )
         if not changed:
             return
@@ -346,7 +348,7 @@ class Command(BaseCommand):
             row["id"]: row
             for row in GamesAndScores.objects.filter(
                 id__in=[game_id for game_id, _ in parsed]
-            ).values("id", "gameScored", *LIVE_SCORE_FIELDS)
+            ).values("id", "gameScored", *SCORE_TRIGGER_FIELDS)
         }
         count = 0
         for game_id, defaults in parsed:

--- a/pickem/pickem_api/management/commands/update_standings.py
+++ b/pickem/pickem_api/management/commands/update_standings.py
@@ -27,13 +27,16 @@ from collections import Counter
 
 from django.core.management.base import BaseCommand
 from django.db.models import F
+from django.utils import timezone
 
 from pickem.utils import get_season
+from pickem_api.live_events import publish_event, standings_channel, standings_event_payload
 from pickem_api.models import (
     Family,
     FamilyMembership,
     GamePicks,
     GamesAndScores,
+    GameWeeks,
     Pool,
     PoolSettings,
     userSeasonPoints,
@@ -42,6 +45,20 @@ from pickem_api.models import (
 logger = logging.getLogger(__name__)
 
 WEEKS = range(1, 19)
+
+
+def maybe_publish_standings_change(old_total, row, week, season):
+    """Publish a live standings event if ``total_points`` changed (or new row).
+
+    ``old_total`` is ``row.total_points`` captured before the recompute, or
+    ``None`` if the row was just created. Best-effort via ``publish_event``
+    (which never raises) — a publish failure must never break the recompute.
+    """
+    if old_total is not None and old_total == row.total_points:
+        return
+    publish_event(
+        standings_channel(row.pool_id, season), standings_event_payload(row, week)
+    )
 
 
 class Command(BaseCommand):
@@ -65,6 +82,7 @@ class Command(BaseCommand):
         season = options["season"] or get_season()
         pool_id_filter = options.get("pool")
         self.stdout.write(f"Recomputing standings for season {season}")
+        current_week = self._current_week()
 
         pick_filter = {"gameseason": season}
         if pool_id_filter:
@@ -131,7 +149,7 @@ class Command(BaseCommand):
             if not user_id:
                 continue
             win_points, tie_points = pool_weights.get(pool_id, (1, 0))
-            row, _ = userSeasonPoints.objects.get_or_create(
+            row, created = userSeasonPoints.objects.get_or_create(
                 pool_id=pool_id,
                 userID=user_id,
                 gameseason=season,
@@ -139,6 +157,7 @@ class Command(BaseCommand):
                     "userEmail": self._email_for(season, pool_id, user_id),
                 },
             )
+            old_total = None if created else row.total_points
 
             correct_by_week = Counter()
             tied_by_week = Counter()
@@ -165,12 +184,29 @@ class Command(BaseCommand):
 
             row.total_points = total
             row.save()
+            maybe_publish_standings_change(old_total, row, current_week, season)
             updated += 1
             self.stdout.write(f" - pool {pool_id} user {user_id}: {total} points")
 
         self.stdout.write(
             self.style.SUCCESS(f"Recomputed standings for {updated} pool members.")
         )
+
+    @staticmethod
+    def _current_week():
+        """Best-effort current week number for today, or None.
+
+        Only used to enrich the live-standings publish payload, so any
+        lookup failure (e.g. no GameWeeks row for today) simply falls back
+        to ``None`` rather than raising — the payload handles week=None.
+        """
+        try:
+            today = timezone.localdate()
+            row = GameWeeks.objects.filter(date=today).first()
+            return row.weekNumber if row else None
+        except Exception:
+            logger.warning("current week lookup failed", exc_info=True)
+            return None
 
     @staticmethod
     def _email_for(season, pool_id, user_id):

--- a/pickem/pickem_api/management/commands/update_standings.py
+++ b/pickem/pickem_api/management/commands/update_standings.py
@@ -47,15 +47,23 @@ logger = logging.getLogger(__name__)
 WEEKS = range(1, 19)
 
 
-def maybe_publish_standings_change(old_total, row, week, season):
-    """Publish a live standings event if ``total_points`` changed (or new row).
+def maybe_publish_standings_change(old_total, old_week_points, row, week, season):
+    """Publish a live standings event if points changed (or new row).
 
     ``old_total`` is ``row.total_points`` captured before the recompute, or
-    ``None`` if the row was just created. Best-effort via ``publish_event``
-    (which never raises) — a publish failure must never break the recompute.
+    ``None`` if the row was just created. ``old_week_points`` is the
+    pre-recompute ``week_{week}_points`` (or ``None`` if unknown/new row).
+    The lobby displays the current week's points, so a cross-week scoring
+    correction that changes ``week_{week}_points`` without moving
+    ``total_points`` still needs to publish. Best-effort via
+    ``publish_event`` (which never raises) — a publish failure must never
+    break the recompute.
     """
-    if old_total is not None and old_total == row.total_points:
-        return
+    if old_total is not None:
+        total_unchanged = old_total == row.total_points
+        week_unchanged = old_week_points == getattr(row, f"week_{week}_points", None)
+        if total_unchanged and week_unchanged:
+            return
     publish_event(
         standings_channel(row.pool_id, season), standings_event_payload(row, week)
     )
@@ -158,6 +166,11 @@ class Command(BaseCommand):
                 },
             )
             old_total = None if created else row.total_points
+            old_week_points = (
+                None
+                if created or current_week is None
+                else getattr(row, f"week_{current_week}_points", None)
+            )
 
             correct_by_week = Counter()
             tied_by_week = Counter()
@@ -184,7 +197,9 @@ class Command(BaseCommand):
 
             row.total_points = total
             row.save()
-            maybe_publish_standings_change(old_total, row, current_week, season)
+            maybe_publish_standings_change(
+                old_total, old_week_points, row, current_week, season
+            )
             updated += 1
             self.stdout.write(f" - pool {pool_id} user {user_id}: {total} points")
 

--- a/pickem/pickem_api/scheduler.py
+++ b/pickem/pickem_api/scheduler.py
@@ -224,16 +224,37 @@ def live_window_active():
     ).exists()
 
 
+def finished_unscored_exists():
+    """True if any current-season game has finaled but hasn't been scored yet.
+
+    update_picks flips gameScored True once it scores a finished game, so this
+    check is idempotent: it drives the scoped downstream recompute below, and
+    once that recompute runs, subsequent ticks see nothing left to do."""
+    from pickem.utils import get_season
+    from pickem_api.models import GamesAndScores
+
+    return GamesAndScores.objects.filter(
+        gameseason=get_season(), statusType="finished", gameScored=False
+    ).exists()
+
+
 def run_live_scores_tick():
     """Fast score refresh: run update_games only during a live window.
 
     Off-window this is a single cheap EXISTS query and returns. On-window it
-    runs update_games (which publishes changed games to Redis)."""
+    runs update_games (which publishes changed games to Redis). If that leaves
+    a finished-but-unscored game, also run the scoped downstream chain
+    (picks -> standings -> rankings -> stats) so a final is reflected within
+    one live tick (~12s) instead of waiting for the next minute's pipeline
+    tick."""
     if not live_window_active():
         return
     if _update_games_running():
         return
     run_job_once("update_games")
+    if finished_unscored_exists():
+        for job_id in ("update_picks", "update_standings", "update_rankings", "update_stats"):
+            run_job_once(job_id)
 
 
 def run_prune_logs():

--- a/pickem/pickem_api/scheduler.py
+++ b/pickem/pickem_api/scheduler.py
@@ -238,6 +238,16 @@ def finished_unscored_exists():
     ).exists()
 
 
+def _job_enabled(job_id):
+    """Respect the superadmin enable/disable toggle in the fast tick (but not
+    is_due — the live tick intentionally runs faster than the configured interval).
+    Missing config row => enabled (default)."""
+    from pickem_api.models import ScheduledJobConfig
+
+    cfg = ScheduledJobConfig.objects.filter(job_id=job_id).first()
+    return cfg is None or cfg.enabled
+
+
 def run_live_scores_tick():
     """Fast score refresh: run update_games only during a live window.
 
@@ -246,15 +256,19 @@ def run_live_scores_tick():
     a finished-but-unscored game, also run the scoped downstream chain
     (picks -> standings -> rankings -> stats) so a final is reflected within
     one live tick (~12s) instead of waiting for the next minute's pipeline
-    tick."""
+    tick. Each step still respects the superadmin enable/disable toggle
+    (though not its interval/is_due, since this tick intentionally runs
+    faster than the configured cadence)."""
     if not live_window_active():
         return
     if _update_games_running():
         return
-    run_job_once("update_games")
+    if _job_enabled("update_games"):
+        run_job_once("update_games")
     if finished_unscored_exists():
         for job_id in ("update_picks", "update_standings", "update_rankings", "update_stats"):
-            run_job_once(job_id)
+            if _job_enabled(job_id):
+                run_job_once(job_id)
 
 
 def run_prune_logs():

--- a/pickem/pickem_api/tests/test_live_events.py
+++ b/pickem/pickem_api/tests/test_live_events.py
@@ -34,3 +34,33 @@ class PublishTests(SimpleTestCase):
                 mock.patch.object(live_events, "_redis_client", return_value=mock.Mock(publish=boom)):
             # Best-effort: a Redis error must be swallowed (logged), not raised.
             live_events.publish_score_event(2627, "3", {"game_id": 1})
+
+
+class StandingsEventTests(SimpleTestCase):
+    def test_standings_channel(self):
+        self.assertEqual(live_events.standings_channel(7, 2627), "standings:7:2627")
+
+    def test_standings_payload(self):
+        from unittest import mock
+        row = mock.Mock(userID="u1", total_points=42, current_rank=2)
+        setattr(row, "week_3_points", 5)
+        p = live_events.standings_event_payload(row, 3)
+        self.assertEqual(p["user_id"], "u1")
+        self.assertEqual(p["total_points"], 42)
+        self.assertEqual(p["week"], 3)
+        self.assertEqual(p["week_points"], 5)
+
+
+class ScorePayloadPeriodsTests(SimpleTestCase):
+    def test_score_payload_includes_periods_and_status_title(self):
+        from unittest import mock
+        g = mock.Mock(id=1, homeTeamScore=7, awayTeamScore=0, statusType="inprogress",
+                      statusTitle="5:00 - 2nd Quarter", gameWinner="",
+                      homeTeamPeriod1=7, homeTeamPeriod2=0, homeTeamPeriod3=0,
+                      homeTeamPeriod4=0, homeTeamPeriodOT=0,
+                      awayTeamPeriod1=0, awayTeamPeriod2=0, awayTeamPeriod3=0,
+                      awayTeamPeriod4=0, awayTeamPeriodOT=0)
+        p = live_events.score_event_payload(g)
+        self.assertEqual(p["status_title"], "5:00 - 2nd Quarter")
+        self.assertEqual(p["home_periods"], [7, 0, 0, 0, 0])
+        self.assertEqual(p["away_periods"], [0, 0, 0, 0, 0])

--- a/pickem/pickem_api/tests/test_live_window.py
+++ b/pickem/pickem_api/tests/test_live_window.py
@@ -3,7 +3,7 @@ from unittest import mock
 from django.test import TestCase
 
 from pickem_api import scheduler
-from pickem_api.models import GamesAndScores
+from pickem_api.models import GamesAndScores, ScheduledJobConfig
 
 
 class LiveWindowTests(TestCase):
@@ -96,3 +96,50 @@ class LiveWindowTests(TestCase):
                 mock.patch.object(scheduler, "run_job_once") as run:
             scheduler.run_live_scores_tick()
             run.assert_called_once_with("update_games")
+
+    def test_job_enabled_defaults_true_when_no_config_row(self):
+        self.assertTrue(scheduler._job_enabled("update_stats"))
+
+    def test_job_enabled_respects_disabled_config_row(self):
+        ScheduledJobConfig.objects.create(job_id="update_stats", enabled=False)
+        self.assertFalse(scheduler._job_enabled("update_stats"))
+        ScheduledJobConfig.objects.create(job_id="update_picks", enabled=True)
+        self.assertTrue(scheduler._job_enabled("update_picks"))
+
+    def test_tick_skips_update_games_when_disabled(self):
+        # Disabling update_games in the superadmin console must not be
+        # silently overridden by the fast live tick.
+        ScheduledJobConfig.objects.create(job_id="update_games", enabled=False)
+        with mock.patch.object(scheduler, "live_window_active", return_value=True), \
+                mock.patch.object(scheduler, "_update_games_running", return_value=False), \
+                mock.patch.object(scheduler, "finished_unscored_exists", return_value=True), \
+                mock.patch.object(scheduler, "run_job_once") as run:
+            scheduler.run_live_scores_tick()
+            self.assertEqual(
+                run.call_args_list,
+                [
+                    mock.call("update_picks"),
+                    mock.call("update_standings"),
+                    mock.call("update_rankings"),
+                    mock.call("update_stats"),
+                ],
+            )
+
+    def test_tick_skips_disabled_downstream_job(self):
+        # A disabled downstream step (e.g. update_stats disabled via the
+        # superadmin console) must be skipped, matching pipeline behavior.
+        ScheduledJobConfig.objects.create(job_id="update_stats", enabled=False)
+        with mock.patch.object(scheduler, "live_window_active", return_value=True), \
+                mock.patch.object(scheduler, "_update_games_running", return_value=False), \
+                mock.patch.object(scheduler, "finished_unscored_exists", return_value=True), \
+                mock.patch.object(scheduler, "run_job_once") as run:
+            scheduler.run_live_scores_tick()
+            self.assertEqual(
+                run.call_args_list,
+                [
+                    mock.call("update_games"),
+                    mock.call("update_picks"),
+                    mock.call("update_standings"),
+                    mock.call("update_rankings"),
+                ],
+            )

--- a/pickem/pickem_api/tests/test_live_window.py
+++ b/pickem/pickem_api/tests/test_live_window.py
@@ -43,3 +43,56 @@ class LiveWindowTests(TestCase):
                 mock.patch.object(scheduler, "run_job_once") as run:
             scheduler.run_live_scores_tick()
             run.assert_not_called()
+
+    def test_no_finished_unscored_when_no_games(self):
+        self.assertFalse(scheduler.finished_unscored_exists())
+
+    def test_finished_unscored_exists_true_for_finished_unscored_game(self):
+        # No currentSeason row exists in this test, so get_season() falls back
+        # to its default (2024) — match that here rather than the "real"
+        # 2627 season used elsewhere.
+        GamesAndScores.objects.create(
+            id=1, slug="a-at-h", competition="1", gameWeek="3", gameyear="2024",
+            gameseason=2024, startTimestamp="2024-09-21T17:00:00Z",
+            statusType="finished", statusTitle="Final",
+            homeTeamId=1, homeTeamSlug="home", homeTeamName="Home",
+            awayTeamId=2, awayTeamSlug="away", awayTeamName="Away",
+            gameScored=False,
+        )
+        self.assertTrue(scheduler.finished_unscored_exists())
+
+    def test_finished_unscored_exists_false_when_already_scored(self):
+        GamesAndScores.objects.create(
+            id=1, slug="a-at-h", competition="1", gameWeek="3", gameyear="2024",
+            gameseason=2024, startTimestamp="2024-09-21T17:00:00Z",
+            statusType="finished", statusTitle="Final",
+            homeTeamId=1, homeTeamSlug="home", homeTeamName="Home",
+            awayTeamId=2, awayTeamSlug="away", awayTeamName="Away",
+            gameScored=True,
+        )
+        self.assertFalse(scheduler.finished_unscored_exists())
+
+    def test_tick_runs_downstream_chain_when_finished_unscored_exists(self):
+        with mock.patch.object(scheduler, "live_window_active", return_value=True), \
+                mock.patch.object(scheduler, "_update_games_running", return_value=False), \
+                mock.patch.object(scheduler, "finished_unscored_exists", return_value=True), \
+                mock.patch.object(scheduler, "run_job_once") as run:
+            scheduler.run_live_scores_tick()
+            self.assertEqual(
+                run.call_args_list,
+                [
+                    mock.call("update_games"),
+                    mock.call("update_picks"),
+                    mock.call("update_standings"),
+                    mock.call("update_rankings"),
+                    mock.call("update_stats"),
+                ],
+            )
+
+    def test_tick_skips_downstream_chain_when_no_finished_unscored(self):
+        with mock.patch.object(scheduler, "live_window_active", return_value=True), \
+                mock.patch.object(scheduler, "_update_games_running", return_value=False), \
+                mock.patch.object(scheduler, "finished_unscored_exists", return_value=False), \
+                mock.patch.object(scheduler, "run_job_once") as run:
+            scheduler.run_live_scores_tick()
+            run.assert_called_once_with("update_games")

--- a/pickem/pickem_api/tests/test_update_games_publish.py
+++ b/pickem/pickem_api/tests/test_update_games_publish.py
@@ -4,6 +4,15 @@ from django.test import TestCase
 
 from pickem_api.management.commands import update_games as ug
 
+# All 10 per-quarter period fields, zeroed — included so an "unchanged" game
+# compares equal across SCORE_TRIGGER_FIELDS (which now includes the periods).
+PERIODS = {
+    "homeTeamPeriod1": 0, "homeTeamPeriod2": 0, "homeTeamPeriod3": 0,
+    "homeTeamPeriod4": 0, "homeTeamPeriodOT": 0,
+    "awayTeamPeriod1": 0, "awayTeamPeriod2": 0, "awayTeamPeriod3": 0,
+    "awayTeamPeriod4": 0, "awayTeamPeriodOT": 0,
+}
+
 
 class PublishChangedGameTests(TestCase):
     def _game(self, **kw):
@@ -11,13 +20,14 @@ class PublishChangedGameTests(TestCase):
             id=401, gameseason=2627, gameWeek="3",
             homeTeamScore=0, awayTeamScore=0, statusType="notstarted",
             statusTitle="", gameWinner="",
+            **PERIODS,
         )
         base.update(kw)
         return mock.Mock(**base)
 
     def test_publishes_when_live_field_changed(self):
         before = {"homeTeamScore": 0, "awayTeamScore": 0, "statusType": "notstarted",
-                  "statusTitle": "", "gameWinner": ""}
+                  "statusTitle": "", "gameWinner": "", **PERIODS}
         after = self._game(homeTeamScore=7, statusType="inprogress")
         with mock.patch.object(ug, "publish_score_event") as pub:
             ug.maybe_publish_game_change(before, after)
@@ -27,9 +37,19 @@ class PublishChangedGameTests(TestCase):
             self.assertEqual(args[1], "3")       # week
             self.assertEqual(args[2]["home_score"], 7)
 
+    def test_publishes_when_only_status_title_changed(self):
+        # Clock tick: statusType unchanged (inprogress), only statusTitle changes.
+        before = {"homeTeamScore": 7, "awayTeamScore": 0, "statusType": "inprogress",
+                  "statusTitle": "5:00 - 2nd Quarter", "gameWinner": "", **PERIODS}
+        after = self._game(homeTeamScore=7, awayTeamScore=0, statusType="inprogress",
+                           statusTitle="4:45 - 2nd Quarter", gameWinner="")
+        with mock.patch.object(ug, "publish_score_event") as pub:
+            ug.maybe_publish_game_change(before, after)
+            self.assertEqual(pub.call_count, 1)
+
     def test_no_publish_when_unchanged(self):
         before = {"homeTeamScore": 7, "awayTeamScore": 0, "statusType": "inprogress",
-                  "statusTitle": "Q1", "gameWinner": ""}
+                  "statusTitle": "Q1", "gameWinner": "", **PERIODS}
         after = self._game(homeTeamScore=7, awayTeamScore=0, statusType="inprogress",
                            statusTitle="Q1", gameWinner="")
         with mock.patch.object(ug, "publish_score_event") as pub:

--- a/pickem/pickem_api/tests/test_update_standings_publish.py
+++ b/pickem/pickem_api/tests/test_update_standings_publish.py
@@ -1,0 +1,35 @@
+from unittest import mock
+
+from django.test import TestCase
+
+from pickem_api.management.commands import update_standings as us
+
+
+class MaybePublishStandingsChangeTests(TestCase):
+    def _row(self, **kw):
+        base = dict(pool_id=7, userID="42", total_points=10, week_3_points=6,
+                    current_rank=2)
+        base.update(kw)
+        return mock.Mock(**base)
+
+    def test_publishes_when_total_changed(self):
+        row = self._row(total_points=13)
+        with mock.patch.object(us, "publish_event") as pub:
+            us.maybe_publish_standings_change(10, row, 3, 2627)
+            self.assertEqual(pub.call_count, 1)
+            channel, payload = pub.call_args.args
+            self.assertEqual(channel, "standings:7:2627")
+            self.assertEqual(payload["total_points"], 13)
+            self.assertEqual(payload["week"], 3)
+
+    def test_publishes_when_newly_created(self):
+        row = self._row(total_points=0)
+        with mock.patch.object(us, "publish_event") as pub:
+            us.maybe_publish_standings_change(None, row, 3, 2627)
+            self.assertEqual(pub.call_count, 1)
+
+    def test_no_publish_when_unchanged(self):
+        row = self._row(total_points=10)
+        with mock.patch.object(us, "publish_event") as pub:
+            us.maybe_publish_standings_change(10, row, 3, 2627)
+            pub.assert_not_called()

--- a/pickem/pickem_api/tests/test_update_standings_publish.py
+++ b/pickem/pickem_api/tests/test_update_standings_publish.py
@@ -15,7 +15,7 @@ class MaybePublishStandingsChangeTests(TestCase):
     def test_publishes_when_total_changed(self):
         row = self._row(total_points=13)
         with mock.patch.object(us, "publish_event") as pub:
-            us.maybe_publish_standings_change(10, row, 3, 2627)
+            us.maybe_publish_standings_change(10, 6, row, 3, 2627)
             self.assertEqual(pub.call_count, 1)
             channel, payload = pub.call_args.args
             self.assertEqual(channel, "standings:7:2627")
@@ -25,11 +25,24 @@ class MaybePublishStandingsChangeTests(TestCase):
     def test_publishes_when_newly_created(self):
         row = self._row(total_points=0)
         with mock.patch.object(us, "publish_event") as pub:
-            us.maybe_publish_standings_change(None, row, 3, 2627)
+            us.maybe_publish_standings_change(None, None, row, 3, 2627)
             self.assertEqual(pub.call_count, 1)
 
     def test_no_publish_when_unchanged(self):
         row = self._row(total_points=10)
         with mock.patch.object(us, "publish_event") as pub:
-            us.maybe_publish_standings_change(10, row, 3, 2627)
+            us.maybe_publish_standings_change(10, 6, row, 3, 2627)
             pub.assert_not_called()
+
+    def test_publishes_when_week_points_changed_but_total_unchanged(self):
+        # A cross-week scoring correction can change week_N_points while
+        # total_points stays the same (e.g. an offsetting adjustment in
+        # another week). The lobby shows week_N_points, so this must still
+        # publish.
+        row = self._row(total_points=10, week_3_points=9)
+        with mock.patch.object(us, "publish_event") as pub:
+            us.maybe_publish_standings_change(10, 6, row, 3, 2627)
+            self.assertEqual(pub.call_count, 1)
+            channel, payload = pub.call_args.args
+            self.assertEqual(channel, "standings:7:2627")
+            self.assertEqual(payload["week"], 3)

--- a/pickem/pickem_homepage/live_views.py
+++ b/pickem/pickem_homepage/live_views.py
@@ -10,9 +10,13 @@ import logging
 import os
 
 from asgiref.sync import sync_to_async
-from django.http import HttpResponseBadRequest, StreamingHttpResponse
+from django.http import (
+    HttpResponseBadRequest,
+    HttpResponseForbidden,
+    StreamingHttpResponse,
+)
 
-from pickem_api.live_events import scores_channel
+from pickem_api.live_events import scores_channel, standings_channel
 
 logger = logging.getLogger(__name__)
 
@@ -96,6 +100,53 @@ async def live_scores_events(request):
 
     resp = StreamingHttpResponse(
         _event_stream(channel), content_type="text/event-stream"
+    )
+    resp["Cache-Control"] = "no-cache"
+    resp["X-Accel-Buffering"] = "no"  # defeat proxy/Cloudflare buffering
+    return resp
+
+
+def _resolve_pool_for_member(user, family_slug, pool_slug):
+    """(pool_id, season) if `user` is a member of the pool, else None. Sync — call
+    via sync_to_async from the async view."""
+    from pickem_api.models import FamilyMembership, Pool
+
+    pool = (
+        Pool.objects.filter(family__slug=family_slug, slug=pool_slug)
+        .values("id", "season", "family_id")
+        .first()
+    )
+    if not pool:
+        return None
+    if not FamilyMembership.objects.filter(
+        user=user, family_id=pool["family_id"]
+    ).exists():
+        return None
+    return pool["id"], pool["season"]
+
+
+async def live_standings_events(request):
+    """SSE stream of live standings changes for ?family=<slug>&pool=<slug>.
+
+    Membership is verified per-request via _resolve_pool_for_member (run off
+    the event loop through sync_to_async) — no sync ORM access in this view
+    body itself.
+    """
+    family_slug = request.GET.get("family", "").strip()
+    pool_slug = request.GET.get("pool", "").strip()
+    if not family_slug or not pool_slug:
+        return HttpResponseBadRequest("family and pool required")
+
+    resolved = await sync_to_async(_resolve_pool_for_member)(
+        request.user, family_slug, pool_slug
+    )
+    if resolved is None:
+        return HttpResponseForbidden("not a member of this pool")
+    pool_id, season = resolved
+
+    resp = StreamingHttpResponse(
+        _event_stream(standings_channel(pool_id, season)),
+        content_type="text/event-stream",
     )
     resp["Cache-Control"] = "no-cache"
     resp["X-Accel-Buffering"] = "no"  # defeat proxy/Cloudflare buffering

--- a/pickem/pickem_homepage/live_views.py
+++ b/pickem/pickem_homepage/live_views.py
@@ -108,18 +108,32 @@ async def live_scores_events(request):
 
 def _resolve_pool_for_member(user, family_slug, pool_slug):
     """(pool_id, season) if `user` is a member of the pool, else None. Sync — call
-    via sync_to_async from the async view."""
-    from pickem_api.models import FamilyMembership, Pool
+    via sync_to_async from the async view.
+
+    Mirrors the status filtering in pickem_api.authz (resolve_family /
+    resolve_pool_context / require_family_membership): an inactive Family
+    (soft-deleted — see family_pool_admin_delete_family), an inactive/archived
+    Pool, or an inactive membership must all be treated the same as "not a
+    member" here, matching how the rest of the tenant surface 404s them.
+    """
+    from pickem_api.models import Family, FamilyMembership, Pool
 
     pool = (
-        Pool.objects.filter(family__slug=family_slug, slug=pool_slug)
+        Pool.objects.filter(
+            family__slug=family_slug,
+            slug=pool_slug,
+            status=Pool.Status.ACTIVE,
+            family__status=Family.Status.ACTIVE,
+        )
         .values("id", "season", "family_id")
         .first()
     )
     if not pool:
         return None
     if not FamilyMembership.objects.filter(
-        user=user, family_id=pool["family_id"]
+        user=user,
+        family_id=pool["family_id"],
+        status=FamilyMembership.Status.ACTIVE,
     ).exists():
         return None
     return pool["id"], pool["season"]

--- a/pickem/pickem_homepage/templates/pickem/family_pool_home.html
+++ b/pickem/pickem_homepage/templates/pickem/family_pool_home.html
@@ -7,7 +7,7 @@
 
 {% block content %}
 
-<div data-lobby-page class="bg-bg-light dark:bg-bg-dark">
+<div data-lobby-page data-family-slug="{{ family.slug }}" data-pool-slug="{{ pool.slug }}" data-live-week="{{ current_week }}" class="bg-bg-light dark:bg-bg-dark">
 
 <!-- ═══════════════════════════════════════ LOBBY HERO ═══════════════════════════════════════ -->
 <div class="lobby-command-hero relative overflow-hidden border-b border-blue-900/40 bg-gradient-to-br from-slate-950 via-slate-900 to-blue-950 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950">
@@ -197,14 +197,14 @@
         {% if week_points_summary %}
         <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
             {% for row in week_points_summary %}
-            <div class="flex items-center justify-between gap-3 rounded-xl border border-border-light dark:border-border-subtle bg-surface-light dark:bg-surface px-4 py-3">
+            <div class="flex items-center justify-between gap-3 rounded-xl border border-border-light dark:border-border-subtle bg-surface-light dark:bg-surface px-4 py-3" data-user-id="{{ row.points.userID }}">
                 <div class="flex items-center gap-3 min-w-0">
                     <span class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-primary/10 text-sm font-black text-primary">#{{ row.rank }}</span>
                     <span class="truncate text-sm font-bold text-text-dark dark:text-white">
                         {% if row.user %}<a href="{% url 'family_pool_user_profile' family.slug pool.slug row.user.id %}" class="hover:text-primary transition-colors">{{ row.user|display_name }}</a>{% else %}Player {{ row.points.userID }}{% endif %}
                     </span>
                 </div>
-                <span class="flex-shrink-0 text-sm font-black text-text-dark dark:text-white">{{ row.week_points }} pts</span>
+                <span class="flex-shrink-0 text-sm font-black text-text-dark dark:text-white" data-user-week-points>{{ row.week_points }} pts</span>
             </div>
             {% endfor %}
         </div>
@@ -642,6 +642,68 @@
             toggle.textContent = expanded ? 'Read more' : 'Show less';
         });
     });
+})();
+</script>
+
+<!-- Live week points via Server-Sent Events (Phase 3c). Patches the Week
+     Points podium in place from /events/standings/; never reorders rows. -->
+<script>
+(function () {
+    if (!window.EventSource) {
+        return;
+    }
+    var page = document.querySelector('[data-lobby-page]');
+    var familySlug = page && page.dataset ? page.dataset.familySlug : '';
+    var poolSlug = page && page.dataset ? page.dataset.poolSlug : '';
+    var week = page && page.dataset ? page.dataset.liveWeek : '';
+    if (!familySlug || !poolSlug) {
+        return;
+    }
+
+    function applyStandingsEvent(ev) {
+        var d;
+        try { d = JSON.parse(ev.data); } catch (e) { return; }
+        if (d.user_id === undefined || d.user_id === null) {
+            return;
+        }
+        var row = document.querySelector('[data-user-id="' + d.user_id + '"]');
+        if (!row) {
+            return;
+        }
+        // week_points is only meaningful for the week this page is showing;
+        // an event for a different week (e.g. a late-scoring prior week)
+        // must not clobber this podium.
+        if (week && String(d.week) === String(week) && d.week_points !== null && d.week_points !== undefined) {
+            var weekPointsEl = row.querySelector('[data-user-week-points]');
+            if (weekPointsEl) {
+                weekPointsEl.textContent = d.week_points + ' pts';
+            }
+        }
+    }
+
+    var sseSource = null;
+    var sseErrorCount = 0;
+    try {
+        sseSource = new EventSource(
+            '/events/standings/?family=' + encodeURIComponent(familySlug) +
+            '&pool=' + encodeURIComponent(poolSlug) +
+            '&week=' + encodeURIComponent(week || '')
+        );
+    } catch (e) {
+        return;
+    }
+    sseSource.onmessage = function (ev) { sseErrorCount = 0; applyStandingsEvent(ev); };
+    sseSource.onerror = function () {
+        // EventSource auto-reconnects on transient drops; only give up after
+        // repeated failures with no data. There's no 30s poll fallback on
+        // this page, so give-up just means the podium stops live-updating
+        // until the next full page load.
+        sseErrorCount++;
+        if (sseErrorCount >= 3) {
+            try { sseSource.close(); } catch (e) {}
+            sseSource = null;
+        }
+    };
 })();
 </script>
 {% endblock %}

--- a/pickem/pickem_homepage/templates/pickem/scores.html
+++ b/pickem/pickem_homepage/templates/pickem/scores.html
@@ -1652,7 +1652,7 @@
         const statusTitleEl = card.querySelector('[data-status-title]');
         if (statusTitleEl && d.status_title) statusTitleEl.textContent = d.status_title;
 
-        const periodLabels = ['1', '2', '3', '4', 'OT'];
+        const periodLabels = ['1', '2', '3', '4'];
         if (Array.isArray(d.home_periods)) {
             d.home_periods.forEach(function (val, idx) {
                 const el = card.querySelector('[data-home-period="' + periodLabels[idx] + '"]');

--- a/pickem/pickem_homepage/templates/pickem/scores.html
+++ b/pickem/pickem_homepage/templates/pickem/scores.html
@@ -361,7 +361,7 @@
                                 <div class="flex items-center justify-between px-3 py-1 text-sm font-semibold text-white {% if game.statusType == 'inprogress' %}bg-gradient-to-r from-green-600 to-green-700{% elif game.statusType == 'finished' %}bg-gradient-to-r from-blue-600 to-blue-700{% else %}bg-gradient-to-r from-gray-600 to-gray-700 dark:from-gray-700 dark:to-gray-800{% endif %}">
                                     <div class="flex items-center gap-2">
                                         <i class="fas {% if game.statusType == 'inprogress' %}fa-circle animate-pulse{% elif game.statusType == 'finished' %}fa-check-circle{% else %}fa-clock{% endif %}"></i>
-                                        <span>{{ game.statusTitle }}</span>
+                                        <span data-status-title>{{ game.statusTitle }}</span>
                                     </div>
                                     <span class="text-xs opacity-90">{{ game|game_start_label }}</span>
                                 </div>
@@ -473,10 +473,10 @@
                                         <div class="score-breakdown">
                                             <div class="flex items-center gap-2">
                                                 <div class="quarters">
-                                                    <span class="quarter-score">{{ game.awayTeamPeriod1|default:"—" }}</span>
-                                                    <span class="quarter-score">{{ game.awayTeamPeriod2|default:"—" }}</span>
-                                                    <span class="quarter-score">{{ game.awayTeamPeriod3|default:"—" }}</span>
-                                                    <span class="quarter-score">{{ game.awayTeamPeriod4|default:"—" }}</span>
+                                                    <span class="quarter-score" data-away-period="1">{{ game.awayTeamPeriod1|default:"—" }}</span>
+                                                    <span class="quarter-score" data-away-period="2">{{ game.awayTeamPeriod2|default:"—" }}</span>
+                                                    <span class="quarter-score" data-away-period="3">{{ game.awayTeamPeriod3|default:"—" }}</span>
+                                                    <span class="quarter-score" data-away-period="4">{{ game.awayTeamPeriod4|default:"—" }}</span>
                                                 </div>
                                                 <div class="total-score text-3xl md:text-4xl font-black text-text-dark dark:text-white pl-3" data-away-score>{{ game.awayTeamScore|default:"0" }}</div>
                                             </div>
@@ -530,10 +530,10 @@
                                         <div class="score-breakdown">
                                             <div class="flex items-center gap-2">
                                                 <div class="quarters">
-                                                    <span class="quarter-score">{{ game.homeTeamPeriod1|default:"—" }}</span>
-                                                    <span class="quarter-score">{{ game.homeTeamPeriod2|default:"—" }}</span>
-                                                    <span class="quarter-score">{{ game.homeTeamPeriod3|default:"—" }}</span>
-                                                    <span class="quarter-score">{{ game.homeTeamPeriod4|default:"—" }}</span>
+                                                    <span class="quarter-score" data-home-period="1">{{ game.homeTeamPeriod1|default:"—" }}</span>
+                                                    <span class="quarter-score" data-home-period="2">{{ game.homeTeamPeriod2|default:"—" }}</span>
+                                                    <span class="quarter-score" data-home-period="3">{{ game.homeTeamPeriod3|default:"—" }}</span>
+                                                    <span class="quarter-score" data-home-period="4">{{ game.homeTeamPeriod4|default:"—" }}</span>
                                                 </div>
                                                 <div class="total-score text-3xl md:text-4xl font-black text-text-dark dark:text-white pl-3" data-home-score>{{ game.homeTeamScore|default:"0" }}</div>
                                             </div>
@@ -1631,7 +1631,13 @@
             // flip hasLiveGames() false and the refresh would no-op, freezing
             // the card. updateLiveScores() re-fetches and sets the correct
             // (finished) status + markup itself.
-            if (d.status === 'inprogress') {
+            // Also covers the rare notstarted -> finished direct jump: if
+            // this game wasn't already inprogress and no OTHER game is live
+            // either, hasLiveGames() would be false and updateLiveScores()
+            // would gate itself into a no-op, leaving this card stale.
+            // Forcing the gate true here (for either case) is harmless —
+            // updateLiveScores() re-fetches and sets the real final status.
+            if (d.status === 'inprogress' || !hasLiveGames()) {
                 card.setAttribute('data-game-status', 'inprogress');
             }
             if (typeof updateLiveScores === 'function') updateLiveScores();
@@ -1641,6 +1647,25 @@
         const away = card.querySelector('[data-away-score]');
         if (home) home.textContent = d.home_score;
         if (away) away.textContent = d.away_score;
+
+        // Complete live game state: status/clock text + per-quarter scores.
+        const statusTitleEl = card.querySelector('[data-status-title]');
+        if (statusTitleEl && d.status_title) statusTitleEl.textContent = d.status_title;
+
+        const periodLabels = ['1', '2', '3', '4', 'OT'];
+        if (Array.isArray(d.home_periods)) {
+            d.home_periods.forEach(function (val, idx) {
+                const el = card.querySelector('[data-home-period="' + periodLabels[idx] + '"]');
+                if (el) el.textContent = (val === null || val === undefined || val === '') ? '—' : val;
+            });
+        }
+        if (Array.isArray(d.away_periods)) {
+            d.away_periods.forEach(function (val, idx) {
+                const el = card.querySelector('[data-away-period="' + periodLabels[idx] + '"]');
+                if (el) el.textContent = (val === null || val === undefined || val === '') ? '—' : val;
+            });
+        }
+
         // reuse existing update animation + completion handling
         card.style.animation = 'none'; card.offsetHeight; card.style.animation = 'fadeIn 0.5s ease-in';
         if (window.scoresLivePulse) window.scoresLivePulse();
@@ -1695,9 +1720,12 @@
     const originalFilterGames = filterGames;
     filterGames = function(filterType) {
         originalFilterGames(filterType);
-        
-        // If user filters to show live games and there are live games, start updates
-        if ((filterType === 'all' || filterType === 'live') && hasLiveGames() && !updateInterval) {
+
+        // If user filters to show live games and there are live games, start
+        // updates — but only the 30s poll fallback; a healthy SSE stream
+        // (sseSource non-null) already covers this, and starting the poll
+        // alongside it would double-update the DOM.
+        if ((filterType === 'all' || filterType === 'live') && hasLiveGames() && !updateInterval && !sseSource) {
             setTimeout(startLiveUpdates, 1000);
         }
     };

--- a/pickem/pickem_homepage/templates/pickem/standings.html
+++ b/pickem/pickem_homepage/templates/pickem/standings.html
@@ -13,7 +13,7 @@
 
 {% block content %}
 
-<div data-standings-page data-family-slug="{{ family.slug }}" data-pool-slug="{{ pool.slug }}" class="max-w-7xl mx-auto px-3 sm:px-4 lg:px-6 py-6">
+<div data-standings-page{% if pool and selected_season == pool.season|stringformat:"s" %} data-family-slug="{{ family.slug }}" data-pool-slug="{{ pool.slug }}"{% endif %} class="max-w-7xl mx-auto px-3 sm:px-4 lg:px-6 py-6">
     <!-- Scoreboard Header -->
     <div class="standings-top-panel mb-5">
         <div class="standings-scoreboard-header px-1 py-2 sm:px-0 sm:py-3">

--- a/pickem/pickem_homepage/templates/pickem/standings.html
+++ b/pickem/pickem_homepage/templates/pickem/standings.html
@@ -13,7 +13,7 @@
 
 {% block content %}
 
-<div data-standings-page class="max-w-7xl mx-auto px-3 sm:px-4 lg:px-6 py-6">
+<div data-standings-page data-family-slug="{{ family.slug }}" data-pool-slug="{{ pool.slug }}" class="max-w-7xl mx-auto px-3 sm:px-4 lg:px-6 py-6">
     <!-- Scoreboard Header -->
     <div class="standings-top-panel mb-5">
         <div class="standings-scoreboard-header px-1 py-2 sm:px-0 sm:py-3">
@@ -137,7 +137,8 @@
             {% for player in player_points %}
             <a href="{% if family and pool %}{% url 'family_pool_user_profile' family.slug pool.slug player.userID %}{% else %}{% url 'user_profile' player.userID %}{% endif %}"
                class="standings-row block bg-white/60 dark:bg-bg-dark/30 rounded-lg px-3 py-2 border border-border-light dark:border-border-subtle hover:border-primary/50 dark:hover:border-primary/50 hover:shadow-card-hover transition-all duration-200"
-               style="animation-delay: {{ forloop.counter0|add:1|floatformat:2 }}s">
+               style="animation-delay: {{ forloop.counter0|add:1|floatformat:2 }}s"
+               data-user-id="{{ player.userID }}">
                 {% with usernames|lookup:player.userID as username %}
                 {% with avatars|lookup:player.userID as avatar %}
 
@@ -165,7 +166,7 @@
 
                     <!-- Points Display -->
                     <div class="text-right flex-shrink-0">
-                        <div class="text-xl font-black text-text-dark dark:text-white">{{ player.total_points|default:0 }}</div>
+                        <div class="text-xl font-black text-text-dark dark:text-white" data-user-total-points>{{ player.total_points|default:0 }}</div>
                         <div class="text-xs text-text-secondary-light dark:text-text-secondary font-semibold uppercase tracking-wide">Points</div>
                     </div>
                 </div>
@@ -348,5 +349,66 @@ document.addEventListener('DOMContentLoaded', function () {
 
 <!-- Alpine.js for dropdown (if not already included) -->
 <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.15.12/dist/cdn.min.js" integrity="sha384-pb6hrQvo4s23cEUFtj0CZkzGE3jyK3pj26RIupXXxhSrrcUA/Cn0lZgcCrGH0t6L" crossorigin="anonymous"></script>
+
+<!-- Live total points via Server-Sent Events (Phase 3c). Patches the
+     leaderboard's points cell in place from /events/standings/; never
+     reorders rows or touches rank badges. -->
+<script>
+(function () {
+    if (!window.EventSource) {
+        return;
+    }
+    var page = document.querySelector('[data-standings-page]');
+    var familySlug = page && page.dataset ? page.dataset.familySlug : '';
+    var poolSlug = page && page.dataset ? page.dataset.poolSlug : '';
+    if (!familySlug || !poolSlug) {
+        // Non-tenant (legacy global) standings page has no family/pool scope
+        // to subscribe to.
+        return;
+    }
+
+    function applyStandingsEvent(ev) {
+        var d;
+        try { d = JSON.parse(ev.data); } catch (e) { return; }
+        if (d.user_id === undefined || d.user_id === null) {
+            return;
+        }
+        var row = document.querySelector('[data-user-id="' + d.user_id + '"]');
+        if (!row) {
+            return;
+        }
+        if (d.total_points === null || d.total_points === undefined) {
+            return;
+        }
+        var totalPointsEl = row.querySelector('[data-user-total-points]');
+        if (totalPointsEl) {
+            totalPointsEl.textContent = d.total_points;
+        }
+    }
+
+    var sseSource = null;
+    var sseErrorCount = 0;
+    try {
+        sseSource = new EventSource(
+            '/events/standings/?family=' + encodeURIComponent(familySlug) +
+            '&pool=' + encodeURIComponent(poolSlug)
+        );
+    } catch (e) {
+        return;
+    }
+    sseSource.onmessage = function (ev) { sseErrorCount = 0; applyStandingsEvent(ev); };
+    sseSource.onerror = function () {
+        // EventSource auto-reconnects on transient drops; only give up after
+        // repeated failures with no data. There's no 30s poll fallback on
+        // this page, so give-up just means the leaderboard stops
+        // live-updating until the next full page load.
+        sseErrorCount++;
+        if (sseErrorCount >= 3) {
+            try { sseSource.close(); } catch (e) {}
+            sseSource = null;
+        }
+    };
+})();
+</script>
 
 {% endblock %}

--- a/pickem/pickem_homepage/tests.py
+++ b/pickem/pickem_homepage/tests.py
@@ -9344,3 +9344,148 @@ class SseStreamShapeTests(TestCase):
             second = await gen.__anext__()
             self.assertIn('data: {"game_id": 1}', second)
             await gen.aclose()
+
+
+class SseStandingsAuthTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        Site.objects.get_or_create(
+            id=1, defaults={"domain": "testserver", "name": "testserver"}
+        )
+        currentSeason.objects.create(season=2526, display_name="2025-2026")
+
+    def setUp(self):
+        self.client = Client()
+        self.family = Family.objects.create(name="Smith Family", slug="smith-family")
+        self.pool = Pool.objects.create(
+            family=self.family,
+            name="Main Pickem",
+            slug="main",
+            season=2526,
+            competition="nfl",
+            is_default=True,
+        )
+        self.member = User.objects.create_user(
+            "standings-member", email="standings-member@example.com", password="pass"
+        )
+        self.outsider = User.objects.create_user(
+            "standings-outsider", email="standings-outsider@example.com", password="pass"
+        )
+        FamilyMembership.objects.create(
+            family=self.family,
+            user=self.member,
+            role=FamilyMembership.Role.MEMBER,
+            status=FamilyMembership.Status.ACTIVE,
+        )
+
+    def test_url_reverses(self):
+        self.assertEqual(reverse("live_standings_events"), "/events/standings/")
+
+    def test_requires_login(self):
+        # RequireLoginForInternalPagesMiddleware should block anonymous access.
+        resp = self.client.get(
+            "/events/standings/",
+            {"family": self.family.slug, "pool": self.pool.slug},
+        )
+        self.assertIn(resp.status_code, (302, 401))
+
+    def test_missing_params_returns_400(self):
+        self.client.force_login(self.member)
+
+        resp = self.client.get("/events/standings/")
+
+        self.assertEqual(resp.status_code, 400)
+
+    def test_missing_pool_param_returns_400(self):
+        self.client.force_login(self.member)
+
+        resp = self.client.get(
+            "/events/standings/", {"family": self.family.slug}
+        )
+
+        self.assertEqual(resp.status_code, 400)
+
+    def test_non_member_gets_403(self):
+        self.client.force_login(self.outsider)
+
+        resp = self.client.get(
+            "/events/standings/",
+            {"family": self.family.slug, "pool": self.pool.slug},
+        )
+
+        self.assertEqual(resp.status_code, 403)
+
+    def test_unknown_pool_gets_403(self):
+        self.client.force_login(self.member)
+
+        resp = self.client.get(
+            "/events/standings/",
+            {"family": self.family.slug, "pool": "does-not-exist"},
+        )
+
+        self.assertEqual(resp.status_code, 403)
+
+    def test_member_gets_stream(self):
+        # No REDIS_URL in test env: _event_stream ends immediately, so the
+        # response is a valid (empty) SSE stream rather than a 403/400.
+        self.client.force_login(self.member)
+
+        resp = self.client.get(
+            "/events/standings/",
+            {"family": self.family.slug, "pool": self.pool.slug},
+        )
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp["Content-Type"], "text/event-stream")
+        self.assertEqual(resp["Cache-Control"], "no-cache")
+        self.assertEqual(resp["X-Accel-Buffering"], "no")
+
+
+class ResolvePoolForMemberTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        currentSeason.objects.create(season=2526, display_name="2025-2026")
+
+    def setUp(self):
+        self.family = Family.objects.create(name="Jones Family", slug="jones-family")
+        self.pool = Pool.objects.create(
+            family=self.family,
+            name="Main Pickem",
+            slug="main",
+            season=2526,
+            competition="nfl",
+            is_default=True,
+        )
+        self.member = User.objects.create_user(
+            "resolve-member", email="resolve-member@example.com", password="pass"
+        )
+        self.outsider = User.objects.create_user(
+            "resolve-outsider", email="resolve-outsider@example.com", password="pass"
+        )
+        FamilyMembership.objects.create(
+            family=self.family,
+            user=self.member,
+            role=FamilyMembership.Role.MEMBER,
+            status=FamilyMembership.Status.ACTIVE,
+        )
+
+    def test_member_resolves_pool_id_and_season(self):
+        from pickem_homepage.live_views import _resolve_pool_for_member
+
+        result = _resolve_pool_for_member(self.member, self.family.slug, self.pool.slug)
+
+        self.assertEqual(result, (self.pool.id, self.pool.season))
+
+    def test_non_member_returns_none(self):
+        from pickem_homepage.live_views import _resolve_pool_for_member
+
+        result = _resolve_pool_for_member(self.outsider, self.family.slug, self.pool.slug)
+
+        self.assertIsNone(result)
+
+    def test_unknown_family_or_pool_returns_none(self):
+        from pickem_homepage.live_views import _resolve_pool_for_member
+
+        result = _resolve_pool_for_member(self.member, "no-such-family", self.pool.slug)
+
+        self.assertIsNone(result)

--- a/pickem/pickem_homepage/tests.py
+++ b/pickem/pickem_homepage/tests.py
@@ -9440,6 +9440,33 @@ class SseStandingsAuthTests(TestCase):
         self.assertEqual(resp["Cache-Control"], "no-cache")
         self.assertEqual(resp["X-Accel-Buffering"], "no")
 
+    def test_member_of_soft_deleted_family_gets_403(self):
+        # family_pool_admin_delete_family flips Family.status to INACTIVE and
+        # the rest of the tenant surface 404s on it; the SSE endpoint must
+        # deny it too, even though the FamilyMembership row is untouched.
+        self.family.status = Family.Status.INACTIVE
+        self.family.save(update_fields=["status"])
+        self.client.force_login(self.member)
+
+        resp = self.client.get(
+            "/events/standings/",
+            {"family": self.family.slug, "pool": self.pool.slug},
+        )
+
+        self.assertEqual(resp.status_code, 403)
+
+    def test_member_of_archived_pool_gets_403(self):
+        self.pool.status = Pool.Status.ARCHIVED
+        self.pool.save(update_fields=["status"])
+        self.client.force_login(self.member)
+
+        resp = self.client.get(
+            "/events/standings/",
+            {"family": self.family.slug, "pool": self.pool.slug},
+        )
+
+        self.assertEqual(resp.status_code, 403)
+
 
 class ResolvePoolForMemberTests(TestCase):
     @classmethod
@@ -9487,5 +9514,36 @@ class ResolvePoolForMemberTests(TestCase):
         from pickem_homepage.live_views import _resolve_pool_for_member
 
         result = _resolve_pool_for_member(self.member, "no-such-family", self.pool.slug)
+
+        self.assertIsNone(result)
+
+    def test_inactive_family_returns_none_even_for_active_member(self):
+        from pickem_homepage.live_views import _resolve_pool_for_member
+
+        self.family.status = Family.Status.INACTIVE
+        self.family.save(update_fields=["status"])
+
+        result = _resolve_pool_for_member(self.member, self.family.slug, self.pool.slug)
+
+        self.assertIsNone(result)
+
+    def test_archived_pool_returns_none_even_for_active_member(self):
+        from pickem_homepage.live_views import _resolve_pool_for_member
+
+        self.pool.status = Pool.Status.ARCHIVED
+        self.pool.save(update_fields=["status"])
+
+        result = _resolve_pool_for_member(self.member, self.family.slug, self.pool.slug)
+
+        self.assertIsNone(result)
+
+    def test_inactive_membership_returns_none(self):
+        from pickem_homepage.live_views import _resolve_pool_for_member
+
+        FamilyMembership.objects.filter(family=self.family, user=self.member).update(
+            status=FamilyMembership.Status.INACTIVE
+        )
+
+        result = _resolve_pool_for_member(self.member, self.family.slug, self.pool.slug)
 
         self.assertIsNone(result)

--- a/pickem/pickem_homepage/tests.py
+++ b/pickem/pickem_homepage/tests.py
@@ -9345,6 +9345,52 @@ class SseStreamShapeTests(TestCase):
             self.assertIn('data: {"game_id": 1}', second)
             await gen.aclose()
 
+    async def test_stream_ends_gracefully_on_redis_error(self):
+        # If Redis subscribe()/get_message() raises (blip, auth failure,
+        # dropped connection), _event_stream's `except Exception: ... return`
+        # should end the generator gracefully (StopAsyncIteration) rather than
+        # propagating the error to the ASGI caller, and cleanup should still
+        # run via `finally`.
+        from unittest import mock
+        import redis.exceptions
+
+        from pickem_homepage import live_views
+
+        cleanup_calls = []
+
+        class FakePubSub:
+            async def subscribe(self, ch):
+                raise redis.exceptions.ConnectionError("connection refused")
+
+            async def get_message(self, ignore_subscribe_messages=True, timeout=0.0):
+                raise redis.exceptions.ConnectionError("connection refused")
+
+            async def unsubscribe(self, ch):
+                cleanup_calls.append("unsubscribe")
+
+            async def aclose(self):
+                cleanup_calls.append("pubsub_aclose")
+
+        class FakeClient:
+            def pubsub(self):
+                return FakePubSub()
+
+            async def aclose(self):
+                cleanup_calls.append("client_aclose")
+
+        with mock.patch.dict("os.environ", {"REDIS_URL": "redis://x:6379/1"}), \
+                mock.patch("redis.asyncio.from_url", return_value=FakeClient()):
+            gen = live_views._event_stream("scores:2627:3")
+            # The generator should end gracefully (StopAsyncIteration), not
+            # propagate the ConnectionError raised by subscribe().
+            with self.assertRaises(StopAsyncIteration):
+                await gen.__anext__()
+
+        # `finally` cleanup should have run even though subscribe() failed.
+        self.assertIn("unsubscribe", cleanup_calls)
+        self.assertIn("pubsub_aclose", cleanup_calls)
+        self.assertIn("client_aclose", cleanup_calls)
+
 
 class SseStandingsAuthTests(TestCase):
     @classmethod

--- a/pickem/pickem_homepage/urls.py
+++ b/pickem/pickem_homepage/urls.py
@@ -187,6 +187,7 @@ urlpatterns = [
     path('invites/<str:invite_code>/', views.accept_invite_link, name='accept_invite_link'),
     path('scores/', views.scores, name='scores'),
     path('events/scores/', live_views.live_scores_events, name='live_scores_events'),
+    path('events/standings/', live_views.live_standings_events, name='live_standings_events'),
     path('standings/', views.standings, name='standings'),
     path('rules/', views.rules, name='rules'),
     path('accounts/signup/', views.account_signup_google_only, name='account_signup'),


### PR DESCRIPTION
## What & why

Final phase of the **live updates** initiative. Makes **player points** update live on the lobby + standings, and completes the **live game state** on `/scores/` (clock/quarter + per-quarter line scores — 3b only did totals + coarse status). Rank/order still update on reload (per the agreed scope; no W/L metric exists in this app).

## Changes

- **Publisher** (`live_events.py`): generalized `publish_event`; `standings_channel(pool,season)` + payload; score payload gains period arrays; `SCORE_TRIGGER_FIELDS` (adds statusTitle + periods).
- **update_games**: publishes clock/quarter/period changes (not just totals) → live game clock.
- **update_standings**: publishes changed points to pool-scoped `standings:{pool}:{season}` (best-effort, `old_total` captured before recompute).
- **Scheduler**: fast tick runs the scoped downstream recompute when a game finals (`finished_unscored_exists`, idempotent via `gameScored`), and now **respects the `ScheduledJobConfig.enabled` toggle** in the fast path (also closes a pre-existing 3b bypass).
- **`/events/standings/`** (async): pool-**membership**-scoped stream — active family/pool/**active membership** only (403 otherwise), all DB access via `sync_to_async` (no sync ORM in the async path — the 3a lesson). Cross-family isolation guaranteed (slug unique within family).
- **Client**: patches points by `data-user-id` on lobby/standings (only subscribes on the current season); patches clock/quarter + per-quarter cells on `/scores/`; folds in deferred 3b minors (filterGames poll guard, notstarted→finished refresh, SSE Redis-error-branch test).

## Testing

- Full suite **925 OK** (6 skipped). New tests: standings publisher, downstream-on-final + enabled-gating, pool-auth (member/non-member/inactive-family/archived-pool/inactive-membership → 403), clock-tick publish, SSE graceful Redis-error end.
- Final whole-branch review (opus) with uvicorn+Redis runtime checks: async-safe, auth correct both directions, channels consistent, no `SynchronousOnlyOperation`.

## Watch in prd verification (deferred Minor)

A game ESPN marks `finished` before posting a winner keeps `gameScored=False`, so the fast tick re-runs the downstream (incl. `update_stats`) every ~12s until the winner posts — self-healing + bounded to live windows, but worth eyeballing scheduler load during a real slate.

## Rollout

Dev auto-tracks `-latest` again (fixed in #154). I'll verify dev is genuinely on the new code + smoke the standings stream before cutting the prd release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Standings now update live without requiring a page refresh.
  - Weekly points and leaderboard totals refresh automatically for authorized pool members.
  - Live scores now display status, clock, quarter, and per-period scoring updates.
  - Finished games trigger faster updates to picks, standings, rankings, and statistics.
- **Bug Fixes**
  - Improved live-update reliability, including graceful recovery from connection errors.
  - Prevented unauthorized access to pool-specific standings updates.
  - Avoided duplicate score polling when a live stream is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->