### PR TITLE
fix(backup): add detailed job logging

### DIFF
--- a/charts/family-pickem/templates/backup-cronjob.yaml
+++ b/charts/family-pickem/templates/backup-cronjob.yaml
@@ -15,49 +15,73 @@ data:
     S3_BUCKET="{{ .Values.backup.s3Bucket | default "family-pickem-backups" }}"
     S3_PREFIX="{{ .Values.backup.s3Prefix | default "postgres" }}"
     KEEP_COUNT={{ .Values.backup.keepCount | default 5 }}
+    START_TIME=$(date +%s)
 
-    echo "[$(date)] Starting PostgreSQL backup..."
+    log() {
+      echo "[$(date -u +'%Y-%m-%dT%H:%M:%SZ')] $*"
+    }
+
+    cleanup() {
+      local exit_code=$?
+      rm -f "${BACKUP_FILE}"
+      if [ "${exit_code}" -eq 0 ]; then
+        log "Removed temporary backup file."
+      else
+        log "ERROR: Backup failed with exit code ${exit_code}; removed temporary backup file."
+      fi
+    }
+    trap cleanup EXIT
+
+    log "Starting PostgreSQL backup: database=pickem host={{ .Release.Name }}-postgresql destination=s3://${S3_BUCKET}/${S3_PREFIX}/ keep_count=${KEEP_COUNT}"
 
     # Install AWS CLI
-    echo "[$(date)] Installing awscli..."
+    log "Installing awscli..."
     apt-get update -qq && apt-get install -y -qq awscli > /dev/null 2>&1
-    echo "[$(date)] awscli installed."
+    log "awscli installed: $(aws --version 2>&1)"
+    log "PostgreSQL client: $(pg_dump --version)"
 
     # Run pg_dump and compress
-    echo "[$(date)] Running pg_dump..."
+    DUMP_START_TIME=$(date +%s)
+    log "Running pg_dump and gzip compression..."
     pg_dump -h {{ .Release.Name }}-postgresql -U postgres -d pickem | gzip > "${BACKUP_FILE}"
     FILESIZE=$(stat -c%s "${BACKUP_FILE}")
-    echo "[$(date)] Dump complete. File size: ${FILESIZE} bytes"
+    DUMP_DURATION=$(( $(date +%s) - DUMP_START_TIME ))
+    log "Dump complete in ${DUMP_DURATION}s. File size: ${FILESIZE} bytes"
 
     if [ "${FILESIZE}" -lt 1000 ]; then
-      echo "[$(date)] ERROR: Backup file is suspiciously small (${FILESIZE} bytes). Aborting."
+      log "ERROR: Backup file is suspiciously small (${FILESIZE} bytes). Aborting."
       exit 1
     fi
 
+    log "Verifying compressed backup integrity..."
+    gzip -t "${BACKUP_FILE}"
+    log "Compressed backup integrity verified."
+
     # Upload to S3
-    echo "[$(date)] Uploading to s3://${S3_BUCKET}/${S3_PREFIX}/pickem-${TIMESTAMP}.sql.gz..."
+    UPLOAD_START_TIME=$(date +%s)
+    log "Uploading to s3://${S3_BUCKET}/${S3_PREFIX}/pickem-${TIMESTAMP}.sql.gz..."
     aws s3 cp "${BACKUP_FILE}" "s3://${S3_BUCKET}/${S3_PREFIX}/pickem-${TIMESTAMP}.sql.gz"
-    echo "[$(date)] Upload complete."
+    UPLOAD_DURATION=$(( $(date +%s) - UPLOAD_START_TIME ))
+    log "Upload complete in ${UPLOAD_DURATION}s."
 
     # Rotate old backups: keep only the most recent $KEEP_COUNT
-    echo "[$(date)] Checking backup rotation (keeping ${KEEP_COUNT} most recent)..."
+    log "Checking backup rotation (keeping ${KEEP_COUNT} most recent)..."
     BACKUPS=$(aws s3 ls "s3://${S3_BUCKET}/${S3_PREFIX}/" | grep '\.sql\.gz$' | sort | awk '{print $4}')
     BACKUP_COUNT=$(echo "${BACKUPS}" | wc -l)
 
     if [ "${BACKUP_COUNT}" -gt "${KEEP_COUNT}" ]; then
       DELETE_COUNT=$((BACKUP_COUNT - KEEP_COUNT))
-      echo "[$(date)] Found ${BACKUP_COUNT} backups. Deleting ${DELETE_COUNT} oldest..."
+      log "Found ${BACKUP_COUNT} backups. Deleting ${DELETE_COUNT} oldest..."
       echo "${BACKUPS}" | head -n "${DELETE_COUNT}" | while read -r FILE; do
-        echo "[$(date)] Deleting s3://${S3_BUCKET}/${S3_PREFIX}/${FILE}"
+        log "Deleting s3://${S3_BUCKET}/${S3_PREFIX}/${FILE}"
         aws s3 rm "s3://${S3_BUCKET}/${S3_PREFIX}/${FILE}"
       done
     else
-      echo "[$(date)] Only ${BACKUP_COUNT} backups found, no rotation needed."
+      log "Only ${BACKUP_COUNT} backups found, no rotation needed."
     fi
 
-    # Clean up temp file
-    rm -f "${BACKUP_FILE}"
-    echo "[$(date)] Backup completed successfully."
+    TOTAL_DURATION=$(( $(date +%s) - START_TIME ))
+    log "Backup completed successfully in ${TOTAL_DURATION}s."
 ---
 apiVersion: batch/v1
 kind: CronJob

--- a/infra/backup/backup-cronjob.yaml
+++ b/infra/backup/backup-cronjob.yaml
@@ -13,49 +13,73 @@ data:
     S3_BUCKET="family-pickem-backups"
     S3_PREFIX="postgres"
     KEEP_COUNT=5
+    START_TIME=$(date +%s)
 
-    echo "[$(date)] Starting PostgreSQL backup..."
+    log() {
+      echo "[$(date -u +'%Y-%m-%dT%H:%M:%SZ')] $*"
+    }
+
+    cleanup() {
+      local exit_code=$?
+      rm -f "${BACKUP_FILE}"
+      if [ "${exit_code}" -eq 0 ]; then
+        log "Removed temporary backup file."
+      else
+        log "ERROR: Backup failed with exit code ${exit_code}; removed temporary backup file."
+      fi
+    }
+    trap cleanup EXIT
+
+    log "Starting PostgreSQL backup: database=pickem host=pickem-prd-postgresql destination=s3://${S3_BUCKET}/${S3_PREFIX}/ keep_count=${KEEP_COUNT}"
 
     # Install AWS CLI
-    echo "[$(date)] Installing awscli..."
+    log "Installing awscli..."
     apt-get update -qq && apt-get install -y -qq awscli > /dev/null 2>&1
-    echo "[$(date)] awscli installed."
+    log "awscli installed: $(aws --version 2>&1)"
+    log "PostgreSQL client: $(pg_dump --version)"
 
     # Run pg_dump and compress
-    echo "[$(date)] Running pg_dump..."
+    DUMP_START_TIME=$(date +%s)
+    log "Running pg_dump and gzip compression..."
     pg_dump -h pickem-prd-postgresql -U postgres -d pickem | gzip > "${BACKUP_FILE}"
     FILESIZE=$(stat -c%s "${BACKUP_FILE}")
-    echo "[$(date)] Dump complete. File size: ${FILESIZE} bytes"
+    DUMP_DURATION=$(( $(date +%s) - DUMP_START_TIME ))
+    log "Dump complete in ${DUMP_DURATION}s. File size: ${FILESIZE} bytes"
 
     if [ "${FILESIZE}" -lt 1000 ]; then
-      echo "[$(date)] ERROR: Backup file is suspiciously small (${FILESIZE} bytes). Aborting."
+      log "ERROR: Backup file is suspiciously small (${FILESIZE} bytes). Aborting."
       exit 1
     fi
 
+    log "Verifying compressed backup integrity..."
+    gzip -t "${BACKUP_FILE}"
+    log "Compressed backup integrity verified."
+
     # Upload to S3
-    echo "[$(date)] Uploading to s3://${S3_BUCKET}/${S3_PREFIX}/pickem-${TIMESTAMP}.sql.gz..."
+    UPLOAD_START_TIME=$(date +%s)
+    log "Uploading to s3://${S3_BUCKET}/${S3_PREFIX}/pickem-${TIMESTAMP}.sql.gz..."
     aws s3 cp "${BACKUP_FILE}" "s3://${S3_BUCKET}/${S3_PREFIX}/pickem-${TIMESTAMP}.sql.gz"
-    echo "[$(date)] Upload complete."
+    UPLOAD_DURATION=$(( $(date +%s) - UPLOAD_START_TIME ))
+    log "Upload complete in ${UPLOAD_DURATION}s."
 
     # Rotate old backups: keep only the most recent $KEEP_COUNT
-    echo "[$(date)] Checking backup rotation (keeping ${KEEP_COUNT} most recent)..."
+    log "Checking backup rotation (keeping ${KEEP_COUNT} most recent)..."
     BACKUPS=$(aws s3 ls "s3://${S3_BUCKET}/${S3_PREFIX}/" | grep '\.sql\.gz$' | sort | awk '{print $4}')
     BACKUP_COUNT=$(echo "${BACKUPS}" | wc -l)
 
     if [ "${BACKUP_COUNT}" -gt "${KEEP_COUNT}" ]; then
       DELETE_COUNT=$((BACKUP_COUNT - KEEP_COUNT))
-      echo "[$(date)] Found ${BACKUP_COUNT} backups. Deleting ${DELETE_COUNT} oldest..."
+      log "Found ${BACKUP_COUNT} backups. Deleting ${DELETE_COUNT} oldest..."
       echo "${BACKUPS}" | head -n "${DELETE_COUNT}" | while read -r FILE; do
-        echo "[$(date)] Deleting s3://${S3_BUCKET}/${S3_PREFIX}/${FILE}"
+        log "Deleting s3://${S3_BUCKET}/${S3_PREFIX}/${FILE}"
         aws s3 rm "s3://${S3_BUCKET}/${S3_PREFIX}/${FILE}"
       done
     else
-      echo "[$(date)] Only ${BACKUP_COUNT} backups found, no rotation needed."
+      log "Only ${BACKUP_COUNT} backups found, no rotation needed."
     fi
 
-    # Clean up temp file
-    rm -f "${BACKUP_FILE}"
-    echo "[$(date)] Backup completed successfully."
+    TOTAL_DURATION=$(( $(date +%s) - START_TIME ))
+    log "Backup completed successfully in ${TOTAL_DURATION}s."
 ---
 apiVersion: batch/v1
 kind: CronJob


### PR DESCRIPTION
## Summary

Adds structured, useful output to the PostgreSQL backup CronJob without exposing credentials.

## Changes

- Log UTC timestamps, backup target, tool versions, and per-step durations.
- Verify the compressed dump before uploading.
- Log cleanup on both success and failure.
- Keep the legacy manifest aligned with the Helm template.

## Verification

- `helm lint charts/family-pickem -f infra/app/values-prd.yaml`
- Rendered production Helm chart and `bash -n` on its backup script.
- `bash -n` on the legacy manifest script.
- `git diff --check`

gate_status: exempt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backup reliability by verifying compressed backup integrity before upload.
  * Ensured temporary backup files are cleaned up after successful or failed runs.
* **Monitoring**
  * Added timestamped progress logs, operation durations, tool version details, and clearer upload, rotation, and failure status messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->