### PR TITLE
fix: disable ASGI lifespan in uvicorn (stops PYTHON-DJANGO-B startup noise)

### DIFF
--- a/docker/app/docker-entrypoint.sh
+++ b/docker/app/docker-entrypoint.sh
@@ -60,5 +60,13 @@ fi
 # only see the pod-spec env. That asymmetry is what stops a rogue second
 # scheduler from starting when someone execs into the scheduler pod (which
 # does set RUN_SCHEDULER at the container level).
+#
+# --lifespan off: Django's ASGIHandler does not implement the ASGI lifespan
+# protocol and raises ValueError on a lifespan scope. Under uvicorn's default
+# (--lifespan auto) that ValueError is caught by uvicorn for graceful
+# fallback, but Sentry's ASGI instrumentation still reports it as an unhandled
+# error on every startup (PYTHON-DJANGO-B). We have no ASGI startup/shutdown
+# hooks (the scheduler starts from apps.ready()), so disabling lifespan is
+# correct and silences the noise.
 export RUN_WEB_SERVER=true
-exec uvicorn pickem.asgi:application --host 0.0.0.0 --port 8000 --workers "${UVICORN_WORKERS:-1}"
+exec uvicorn pickem.asgi:application --host 0.0.0.0 --port 8000 --workers "${UVICORN_WORKERS:-1}" --lifespan off


### PR DESCRIPTION
## What

Add \`--lifespan off\` to the uvicorn command in \`docker/app/docker-entrypoint.sh\`.

## Why

Django's \`ASGIHandler\` does not implement the ASGI **lifespan** protocol and raises
\`ValueError: Django can only handle ASGI/HTTP connections, not lifespan.\` on a lifespan scope.
Under uvicorn's default \`--lifespan auto\`, that error is caught by uvicorn for graceful fallback,
but **Sentry's ASGI instrumentation still reports it as an unhandled error on every web startup** —
this is Sentry issue **PYTHON-DJANGO-B** (24 events, escalating, seen on 0.0.199).

We have no ASGI startup/shutdown hooks (the APScheduler is started from \`apps.ready()\`, not via
lifespan), so disabling lifespan is the correct, minimal fix and eliminates the recurring noise.

## Testing

- \`manage.py check\` clean, \`makemigrations --check\` clean
- Full suite: **926 tests OK** (6 skipped)
- Verified in prod that the app has no lifespan handlers (scheduler starts from \`apps.ready()\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)