### PR TITLE
Structural live updates: lobby/standings reorder + Week Points polish + Message Board move (#159)

### DIFF
--- a/docs/superpowers/plans/2026-08-03-structural-live-updates.md
+++ b/docs/superpowers/plans/2026-08-03-structural-live-updates.md
@@ -1,0 +1,268 @@
+# Structural Live Updates (#159) Implementation Plan
+
+> **For agentic workers:** Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the lobby & standings leaderboards self-update their *structure*
+(new rows, reordering) live, add a scores pre-kickoff fallback, and polish the
+lobby Week Points block (rank-after-first-game, avatars, paginate-at-12).
+
+**Architecture:** SSE stays the change-signal. Value patches remain the instant
+fast path; on top of them, a **debounced, coalesced leaderboard refetch** re-renders
+the leaderboard container from the server (correct order + any new rows). Server
+stays the single source of layout truth. See spec
+`docs/superpowers/specs/2026-08-03-structural-live-updates-design.md`.
+
+**Tech Stack:** Django 5.2 templates, vanilla JS (no new deps), Redis SSE (unchanged).
+
+## Global Constraints
+
+- Vanilla JS only; no new frontend dependency.
+- No `?v=` cache-buster on `{% static %}` URLs.
+- No changes to the SSE publish path or async views — client + template + one
+  view helper only.
+- Rebuild `tailwind.css` via `npm run build:prod` only if real utility classes
+  are added; else discard version-only churn.
+- §2 (scores kickoff/finish swap) is **already implemented** — do not rebuild it.
+
+---
+
+### Task 1: Week Points rank rule — rank only after a completed game (§5a)
+
+**Files:**
+- Modify: `pickem/pickem_homepage/views.py` — `build_week_points_summary` (~L462)
+  and its caller in `family_pool_home` (~L1108).
+- Test: `pickem/pickem_homepage/tests.py` — `BuildWeekPointsSummaryTests`.
+
+**Interfaces:**
+- Produces: `build_week_points_summary(pool, gameseason, current_week,
+  week_has_completed_game)` — same return list of dicts, but each `row['rank']`
+  is `None` when `week_has_completed_game` is False, else `1..N`.
+
+- [ ] **Step 1: Write failing tests.** Add to `BuildWeekPointsSummaryTests`:
+
+```python
+def test_rank_is_none_when_no_completed_game(self):
+    rows = build_week_points_summary(self.pool, 2526, "1", week_has_completed_game=False)
+    self.assertTrue(len(rows) >= 1)
+    self.assertTrue(all(r["rank"] is None for r in rows))
+
+def test_rank_is_numeric_when_a_game_completed(self):
+    rows = build_week_points_summary(self.pool, 2526, "1", week_has_completed_game=True)
+    self.assertEqual([r["rank"] for r in rows], list(range(1, len(rows) + 1)))
+```
+
+(Existing tests call the helper with 3 args — update them to pass
+`week_has_completed_game=True` so they keep asserting numeric ranks.)
+
+- [ ] **Step 2: Run tests, verify they fail** (TypeError: unexpected kwarg / rank not None).
+
+Run: `cd pickem && uv run python manage.py test pickem_homepage.tests.BuildWeekPointsSummaryTests --settings=pickem.test_settings -v2`
+
+- [ ] **Step 3: Implement.** Add the parameter and gate the rank:
+
+```python
+def build_week_points_summary(pool, gameseason, current_week, week_has_completed_game):
+    # ... unchanged filtering + sort ...
+    return [
+        {
+            'rank': (rank if week_has_completed_game else None),
+            'points': points,
+            'week_points': getattr(points, week_points_field) or 0,
+            'user': week_points_users.get(int(points.userID)) if str(points.userID).isdigit() else None,
+        }
+        for rank, points in enumerate(week_points_rows, 1)
+    ]
+```
+
+In `family_pool_home`, compute the flag and pass it:
+
+```python
+from pickem_api.models import GamesAndScores
+week_has_completed_game = GamesAndScores.objects.filter(
+    gameseason=gameseason, gameWeek=current_week, statusType="finished"
+).exists()
+week_points_summary = build_week_points_summary(
+    pool, gameseason, current_week, week_has_completed_game
+)
+```
+
+- [ ] **Step 4: Run tests, verify pass.**
+- [ ] **Step 5: Commit** (`feat(lobby): Week Points rank only after first completed game`).
+
+---
+
+### Task 2: Week Points template — avatars, rank display, paginate at 12 (§5b, §5c)
+
+**Files:**
+- Modify: `pickem/pickem_homepage/templates/pickem/family_pool_home.html`
+  (grid ~L198, row ~L200-208).
+
+**Interfaces:**
+- Consumes: `row.rank` (None or int), `row.points.userID`, `row.user`.
+
+- [ ] **Step 1: Paginate at 12.** Change `data-week-points-page-size="10"` → `"12"`.
+
+- [ ] **Step 2: Add avatar + rank label to the row.** Replace the rank-only badge
+  (`<span …>#{{ row.rank }}</span>`) with an avatar image plus a rank/dash label:
+
+```django
+<span class="flex-shrink-0 w-6 text-center text-sm font-black {% if row.rank %}text-primary{% else %}text-text-secondary-light dark:text-text-secondary{% endif %}">{% if row.rank %}{{ row.rank }}{% else %}<span title="Ranking begins after the first completed game">&ndash;</span>{% endif %}</span>
+{% with row.points.userID|lookupavatar as avatar %}
+<img src="{{ avatar|default:'https://www.gravatar.com/avatar/?d=identicon&s=64' }}" alt="" class="h-8 w-8 flex-shrink-0 rounded-full border border-border-light dark:border-border-subtle object-cover" onerror="this.src='https://www.gravatar.com/avatar/?d=identicon&s=64'">
+{% endwith %}
+```
+
+- [ ] **Step 3: Add reorder value attribute** to the row for Task 3's refetch
+  trigger: on the `[data-week-points-row]` element add
+  `data-week-points-value="{{ row.week_points }}"`.
+
+- [ ] **Step 4: Verify render.** With the dev server running:
+  `curl -s http://localhost:8000/... | grep -c 'data-week-points-value'` (sanity),
+  and visually confirm avatars + `–` before any game, numeric rank after.
+
+- [ ] **Step 5: Commit** (`feat(lobby): avatars + rank label in Week Points block`).
+
+---
+
+### Task 3: Lobby leaderboard structural refetch — new rows + reorder (§3)
+
+**Files:**
+- Modify: `pickem/pickem_homepage/templates/pickem/family_pool_home.html` — the
+  live-standings SSE `<script>` (~L662-719) and the pagination script (~L725) to
+  expose a re-init hook.
+
+**Interfaces:**
+- Consumes: pagination script must expose `window.__weekPointsPaginate =
+  function () { … }` (or similar) so the refetch can re-init after swapping.
+
+- [ ] **Step 1: Expose a pagination re-init hook.** Wrap the pagination IIFE body
+  in a named `function initWeekPointsPager()` and assign it to
+  `window.__weekPointsPaginate`; call it once on load. (Idempotent: it re-reads
+  rows + page size from the DOM each call.)
+
+- [ ] **Step 2: Add a debounced leaderboard refetch** to the SSE script:
+
+```javascript
+var refetchTimer = null;
+function scheduleLeaderboardRefetch() {
+    if (refetchTimer) { clearTimeout(refetchTimer); }
+    refetchTimer = setTimeout(function () {
+        refetchTimer = null;
+        fetch(window.location.href, {
+            headers: { 'X-Requested-With': 'XMLHttpRequest', 'Cache-Control': 'no-store' },
+            cache: 'no-store', credentials: 'same-origin'
+        }).then(function (r) { return r.ok ? r.text() : null; })
+          .then(function (html) {
+              if (!html) { return; }
+              var doc = new DOMParser().parseFromString(html, 'text/html');
+              var fresh = doc.querySelector('[data-week-points-grid]');
+              var current = document.querySelector('[data-week-points-grid]');
+              if (fresh && current) {
+                  current.innerHTML = fresh.innerHTML;
+                  if (typeof window.__weekPointsPaginate === 'function') {
+                      window.__weekPointsPaginate();
+                  }
+              }
+          }).catch(function () {});
+    }, 1500);
+}
+```
+
+- [ ] **Step 3: Trigger it from `applyStandingsEvent`.** After the existing
+  in-place value patch, add: if the row is missing (`!row`) **or** the incoming
+  `week_points` differs from the row's `data-week-points-value`, call
+  `scheduleLeaderboardRefetch()`. (Value patch stays for instant feedback; the
+  debounced refetch settles order + brings in new rows.)
+
+- [ ] **Step 4: Verify** with a scripted dev change: bump a member's week points
+  so ranks reorder → row moves without reload; add a member → row appears.
+
+- [ ] **Step 5: Commit** (`feat(lobby): live reorder + new-row refetch for Week Points`).
+
+---
+
+### Task 4: Standings page structural refetch — reorder (§3)
+
+**Files:**
+- Modify: `pickem/pickem_homepage/templates/pickem/standings.html` — row (~L137)
+  and the SSE `<script>` (~L354-402).
+
+- [ ] **Step 1: Add a reorder value attribute** to each `.standings-row`:
+  `data-total-points="{{ player.totalPoints }}"` (use the field the leaderboard
+  is ordered by — confirm the exact ordering field in the view before wiring).
+
+- [ ] **Step 2: Add the same debounced refetch** as Task 3, swapping the
+  leaderboard container (the `.space-y-1.5` list wrapper — give it a stable
+  `data-standings-list` hook). No pagination on this page, so no re-init hook.
+
+- [ ] **Step 3: Trigger from `applyStandingsEvent`** on missing row or changed value.
+
+- [ ] **Step 4: Verify** reorder on `/standings/` via a scripted dev change.
+
+- [ ] **Step 5: Commit** (`feat(standings): live row reorder refetch`).
+
+---
+
+### Task 5: Scores pre-kickoff heartbeat fallback (§4)
+
+**Files:**
+- Modify: `pickem/pickem_homepage/templates/pickem/scores.html` — near the SSE
+  wiring (~L1708).
+
+**Rationale:** §2 works when the SSE kickoff event arrives. If SSE is down (fell
+back to the 30s poll, which is gated on `hasLiveGames()`), a kickoff won't swap.
+This adds a cheap safety net.
+
+- [ ] **Step 1: Add a heartbeat** that, every 60s, if any card is `notstarted`
+  with a kickoff time at/before now, calls `updateLiveScores()` (force the gate as
+  `applyScoreEvent` does). Self-limits: stops when no such card remains.
+  (Reuse the existing kickoff-time data attribute if present; otherwise read the
+  card's start time — confirm which attribute holds it before wiring.)
+
+- [ ] **Step 2: Verify** it no-ops when nothing is imminent and fires once a
+  notstarted card's kickoff passes.
+
+- [ ] **Step 3: Commit** (`feat(scores): pre-kickoff heartbeat fallback`).
+
+---
+
+### Task 6: Contract-lock tests + full suite (§6)
+
+**Files:**
+- Test: `pickem/pickem_homepage/tests.py`.
+
+- [ ] **Step 1: Add render-contract tests** asserting the lobby renders
+  `data-week-points-value` on rows and `data-week-points-grid` on the container,
+  and standings renders `data-user-id` + `data-total-points` + `data-standings-list`.
+  (A GET as an authenticated pool member; reuse existing test fixtures/patterns.)
+
+- [ ] **Step 2: Run the full suite** (mirrors CI):
+
+```bash
+cd pickem
+uv run python manage.py check --settings=pickem.test_settings
+uv run python manage.py makemigrations --check --dry-run --settings=pickem.test_settings
+uv run python manage.py test --settings=pickem.test_settings -v2
+```
+
+- [ ] **Step 3: Commit** (`test: lock live-update DOM contract`).
+
+---
+
+## Ship
+
+After all tasks green: run `pr-review-toolkit:review-pr`, fix Critical/Important,
+then ship-it (PR → checks → CodeRabbit → merge → release → prd verify). One
+release covering: Message Board reorder + Week Points polish + live structural
+updates.
+
+## Self-Review
+
+- **Spec coverage:** §2 (already done — Task 5 covers only the fallback), §3
+  (Tasks 3, 4), §5a (Task 1), §5b/c (Task 2), §6 (Task 6). ✓
+- **Type consistency:** helper signature `build_week_points_summary(pool,
+  gameseason, current_week, week_has_completed_game)` used identically in view,
+  helper, and tests. ✓
+- **Open confirmations for the implementer:** exact standings ordering field
+  (Task 4 Step 1), the scores card kickoff-time attribute (Task 5 Step 1). Both
+  flagged inline to verify before wiring.

--- a/docs/superpowers/plans/2026-08-03-structural-live-updates.md
+++ b/docs/superpowers/plans/2026-08-03-structural-live-updates.md
@@ -203,7 +203,15 @@ function scheduleLeaderboardRefetch() {
 
 ---
 
-### Task 5: Scores pre-kickoff heartbeat fallback (§4)
+### Task 5: Scores pre-kickoff heartbeat fallback (§4) — DEFERRED to #160
+
+**Deferred during implementation.** §2 was found already working end-to-end via
+SSE (`statusType` is a publish trigger), so this only guards the rare "SSE fully
+down at the exact kickoff second" edge. There is no clean per-card kickoff-time
+attribute to drive it, and a coarse always-poll heartbeat is wasteful. Not worth
+the fragility now; revisit under #160 if the edge ever bites.
+
+_Original design (for reference):_
 
 **Files:**
 - Modify: `pickem/pickem_homepage/templates/pickem/scores.html` — near the SSE

--- a/docs/superpowers/specs/2026-08-03-structural-live-updates-design.md
+++ b/docs/superpowers/specs/2026-08-03-structural-live-updates-design.md
@@ -1,0 +1,148 @@
+# Structural Live Updates (#159) — Design
+
+**Status:** Approved 2026-08-03. Follow-on to the SSE live-updates initiative
+(Phases 1–3c shipped through `family-pickem-0.0.199`; see
+`docs/superpowers/specs/2026-08-02-live-updates-design.md`).
+
+## Problem
+
+SSE currently only **patches existing DOM text** — a game card's score, a
+leaderboard row's week-points cell. It cannot create, remove, or reorder
+elements. So three structural changes still require a manual page reload:
+
+1. **Scores card status swap** — a game going `notstarted → inprogress`
+   (kickoff) or `inprogress → finished` changes the card's *layout*, not just
+   its numbers. SSE flips `data-game-status` and patches score text, but the
+   card keeps its old structure until reload.
+2. **Lobby / standings section first-appearance** — a leaderboard row (or a
+   whole section) that isn't yet in the DOM when its first event arrives.
+3. **Rank reorder** — when week-points/points change enough to change row
+   order, the values update in place but the rows never move.
+
+This is the reload friction observed during the 0.0.199 / 0.0.202 live demos.
+
+## Current state (verified 2026-08-03)
+
+| Surface | Has now | Structural gap |
+|---|---|---|
+| `/scores/` | Score-text patch via SSE (`applyScoreEvent`); full-page card refetch (`updateLiveScores`) **gated on `hasLiveGames()`** | Kickoff & finish don't swap card layout (gate is false pre-kickoff) |
+| Lobby (`family_pool_home.html`) | Week-points value patch by `data-user-id` (`applyStandingsEvent`) | Section first-appearance, new member rows, rank reorder |
+| `/standings/` | Points value patch by `data-user-id` (`applyStandingsEvent`) | Rank reorder |
+
+Relevant existing code:
+- `pickem/pickem_homepage/templates/pickem/scores.html` — `applyScoreEvent`
+  (~L1613), `updateLiveScores` (~L1369, does card-by-card `innerHTML` swap),
+  `hasLiveGames` (~L1365), EventSource wiring (~L1677).
+- `pickem/pickem_homepage/templates/pickem/family_pool_home.html` and
+  `standings.html` — `applyStandingsEvent` patches `[data-user-week-points]` /
+  points cell by `[data-user-id]`.
+- `pickem/pickem_api/scheduler.py` — `live_window_active()` (L217) is true
+  **only when a game is already `inprogress`**, so the fast 12s
+  `run_live_scores_tick` does not run before kickoff; the kickoff status write
+  comes from the 60s `run_pipeline_tick` instead.
+
+## Chosen approach: SSE-signaled structural refetch (Approach A)
+
+SSE remains the "something changed" signal. The existing **value-patch** path
+stays the untouched fast path. We add **one** new path: when an event implies a
+change the client can't express by editing text, the client triggers a
+**debounced refetch** of just the affected page region and swaps its
+`innerHTML`. The server stays the single source of layout truth — no template
+duplication, no rendering in the async/SSE path.
+
+Rejected alternatives:
+- **B — dedicated fragment endpoints:** lighter payloads but new views/routes +
+  partial extraction + tests; deferred to #160 as an optimization if payload
+  size ever matters.
+- **C — push rendered HTML over SSE:** requires async template rendering
+  (`sync_to_async`), fatter Redis messages, awkward per-user styling. Rejected.
+
+## Components
+
+### 1. Shared refetch coordinator (new vanilla-JS helper)
+
+A small helper, reused by scores + lobby + standings clients:
+
+- `scheduleStructuralRefetch(regionKey)` — trailing-debounced (~1.5s). A burst
+  of events coalesces into a single refetch. Multiple distinct `regionKey`s
+  requested within the window are all swapped by the one fetch.
+- On fire: `fetch(window.location.href, { headers: XHR + no-store,
+  credentials: 'same-origin' })`, parse with `DOMParser`, and for each
+  registered region swap the container's `innerHTML` from the fresh document,
+  then re-run that region's layout hooks.
+- This generalizes the swap logic already in `updateLiveScores`; extract the
+  fetch-parse-swap core so both the interval poll and SSE call the same code.
+- Vanilla JS only — no new dependency; matches existing style.
+
+**Region registry** (per page, declared where the client is wired):
+- `scores` → swap each `.game-score-card` by index (as `updateLiveScores` does
+  today) + the weekly-performance and week-points-leaderboard blocks; re-init
+  the week-points pager/layout manager.
+- `leaderboard` → swap the lobby podium+list container / standings table body;
+  re-init pagination + `weekPointsLayoutManager`.
+
+### 2. Scores — kickoff / finish swap
+
+In `applyScoreEvent`: when the event's `status` ≠ the card's current
+`data-game-status`, call `scheduleStructuralRefetch('scores')` (in addition to
+flipping `data-game-status` so `hasLiveGames()` stays correct for the interval
+poll). The refetch renders the correct layout for the new status.
+
+- The common in-progress score tick (no status change) keeps the current
+  in-place value patch — no refetch.
+- The SSE-triggered refetch path is **ungated from `hasLiveGames()`** so kickoff
+  works when nothing is live yet. (The 30s interval poll stays gated as-is.)
+
+### 3. Lobby / standings — section appearance + reorder
+
+In `applyStandingsEvent`, after locating the row by `data-user-id`:
+
+- **No row exists** for that `user_id` → structural (new member / section
+  first-appearance) → `scheduleStructuralRefetch('leaderboard')`.
+- Row exists but the new `week_points`/`points` would **change its order**
+  relative to its immediate neighbors → `scheduleStructuralRefetch('leaderboard')`.
+- Otherwise → in-place value patch (unchanged current behavior).
+
+Order-change detection: compare the incoming value against the adjacent visible
+rows' values (read from their `data-*` value attributes); if the new value
+crosses a neighbor, it's a reorder.
+
+### 4. Trigger reliability (fallback)
+
+Because `live_window_active()` is false pre-kickoff, the kickoff status event
+comes from the 60s pipeline tick, and the existing 30s interval poll is also
+gated on `hasLiveGames()`. SSE is therefore the sole prompt kickoff trigger. To
+guarantee the swap even if an SSE event is dropped or missed, add a
+**lightweight client heartbeat**: when the page has `notstarted` cards whose
+kickoff time is at/past `now`, run a low-frequency (~60s)
+`scheduleStructuralRefetch('scores')` until they flip. Cheap, self-limiting, and
+the debounce ensures heartbeat + SSE never double-fetch.
+
+### 5. Testing
+
+The behavior is client-side JS, which Django can't unit-test directly. Scope:
+
+- **Django tests (contract lock):** assert each page renders the container
+  hooks and `data-*` attributes the client depends on — `data-game-status` and
+  `data-game-id` on cards, `data-user-id` (+ the value attributes used for
+  reorder detection) on leaderboard rows, and the region container ids — so a
+  template change can't silently break the client contract.
+- **No server behavior changes**, so the existing suite covers regressions.
+- **Behavioral verification:** scripted live demo on dev (as done for 0.0.199 /
+  0.0.202): drive a `notstarted → inprogress → finished` transition and a
+  point change that reorders rows, confirm swaps with no reload, then restore.
+
+## Out of scope (→ epic #160)
+
+- Fragment endpoints (Approach B) as a payload optimization.
+- Live **total-points / rank value** updates beyond week-points.
+- Stats, team-records, message-board, and season-winner live surfaces.
+
+## Global constraints
+
+- Vanilla JS only; no new frontend dependency.
+- No `?v=` cache-buster on `{% static %}` URLs (see CLAUDE.md).
+- No server behavior changes to the SSE publish path or views; this is a
+  client + template-contract change only.
+- Any real utility-class additions require `npm run build:prod`; discard
+  version-only `tailwind.css` churn.

--- a/docs/superpowers/specs/2026-08-03-structural-live-updates-design.md
+++ b/docs/superpowers/specs/2026-08-03-structural-live-updates-design.md
@@ -118,7 +118,35 @@ kickoff time is at/past `now`, run a low-frequency (~60s)
 `scheduleStructuralRefetch('scores')` until they flip. Cheap, self-limiting, and
 the debounce ensures heartbeat + SSE never double-fetch.
 
-### 5. Testing
+### 5. Week Points block polish (lobby — final step)
+
+Bundled cosmetic/rank improvements to the lobby Week Points block
+(`family_pool_home.html`, the podium grid from 0.0.202). These share the block
+and the "has a completed game" condition, so they land as the last step:
+
+- **Rank only after a completed game.** `build_week_points_summary` currently
+  assigns `rank = 1..N` unconditionally. Change it to assign a numeric rank
+  **only when the current week has ≥1 completed game**; otherwise `rank = None`.
+  The template renders `#N` when `row.rank` is set and `–` (em/en-dash, matching
+  the existing standings-preview treatment at ~L348) when it is `None`. Before
+  any game completes, everyone is equal, so every row shows `–`.
+  - Detection: a boolean `week_has_completed_game` (any `GamesAndScores` row for
+    the season+week with `statusType='finished'`), computed in the view and
+    passed into the helper so the helper stays pure and unit-testable.
+- **User avatars (like the scores page).** Each Week Points row renders the
+  member's avatar via `{% with row.points.userID|lookupavatar as avatar %}` →
+  `<img class="w-8 h-8 rounded-full border …" src="{{ avatar|default:'https://www.gravatar.com/avatar/?d=identicon&s=64' }}">`,
+  matching the scores-page styling. The numeric rank (`#N`, when present) shows as
+  a small label beside the avatar; when unranked, the `–` shows in its place.
+  `lookupavatar` is already loaded (`pickem_homepage_extras`) in the template.
+- **Paginate at 12, not 10.** The grid is 3 columns × 4 rows, so
+  `data-week-points-page-size="10"` → `"12"` fills a clean page.
+
+Interaction with §3: pre-completion all rows are equal and unranked, so no
+reorder occurs; post-completion ranks are numeric and the §3 reorder-refetch
+applies normally.
+
+### 6. Testing
 
 The behavior is client-side JS, which Django can't unit-test directly. Scope:
 
@@ -127,7 +155,10 @@ The behavior is client-side JS, which Django can't unit-test directly. Scope:
   `data-game-id` on cards, `data-user-id` (+ the value attributes used for
   reorder detection) on leaderboard rows, and the region container ids — so a
   template change can't silently break the client contract.
-- **No server behavior changes**, so the existing suite covers regressions.
+- **Server-side rank rule (§5):** extend the existing
+  `BuildWeekPointsSummaryTests` — assert every row has `rank is None` when the
+  week has no completed game, and `rank = 1..N` once a completed game exists.
+- **No other server behavior changes**, so the existing suite covers regressions.
 - **Behavioral verification:** scripted live demo on dev (as done for 0.0.199 /
   0.0.202): drive a `notstarted → inprogress → finished` transition and a
   point change that reorders rows, confirm swaps with no reload, then restore.

--- a/docs/superpowers/specs/2026-08-03-structural-live-updates-design.md
+++ b/docs/superpowers/specs/2026-08-03-structural-live-updates-design.md
@@ -83,6 +83,15 @@ A small helper, reused by scores + lobby + standings clients:
 
 ### 2. Scores — kickoff / finish swap
 
+> **Implementation note (found during planning):** this is **already
+> implemented and working**. `statusType` is in `SCORE_TRIGGER_FIELDS`
+> (`live_events.py`), so a kickoff/finish publishes an SSE event; `applyScoreEvent`
+> (`scores.html` ~L1618) already detects the status change, forces `hasLiveGames()`
+> true, and calls `updateLiveScores()` for a full card refetch. The 0.0.199/0.0.202
+> demo "didn't swap" only because the DB was edited directly, bypassing
+> `update_games`/publish. **No change needed here** beyond the §4 fallback.
+
+
 In `applyScoreEvent`: when the event's `status` ≠ the card's current
 `data-game-status`, call `scheduleStructuralRefetch('scores')` (in addition to
 flipping `data-game-status` so `hasLiveGames()` stays correct for the interval

--- a/pickem/pickem_homepage/templates/pickem/family_pool_home.html
+++ b/pickem/pickem_homepage/templates/pickem/family_pool_home.html
@@ -680,7 +680,12 @@
     // needs fresh server-rendered rows. Coalesces a burst of events into one
     // fetch; the value patch below still gives instant feedback in the meantime.
     var refetchTimer = null;
+    var refetchGeneration = 0;
     function scheduleLeaderboardRefetch() {
+        // Bump a generation token each schedule; an in-flight fetch that resolves
+        // out of order (a slower older request finishing after a newer one) is
+        // discarded so it can't overwrite fresher rows with stale HTML.
+        var generation = ++refetchGeneration;
         if (refetchTimer) { clearTimeout(refetchTimer); }
         refetchTimer = setTimeout(function () {
             refetchTimer = null;
@@ -689,7 +694,7 @@
                 cache: 'no-store', credentials: 'same-origin'
             }).then(function (r) { return r.ok ? r.text() : null; })
               .then(function (html) {
-                  if (!html) { return; }
+                  if (!html || generation !== refetchGeneration) { return; }
                   var doc = new DOMParser().parseFromString(html, 'text/html');
                   var fresh = doc.querySelector('[data-week-points-grid]');
                   var current = document.querySelector('[data-week-points-grid]');

--- a/pickem/pickem_homepage/templates/pickem/family_pool_home.html
+++ b/pickem/pickem_homepage/templates/pickem/family_pool_home.html
@@ -393,41 +393,6 @@
         </div>
     </div>
 
-    <!-- ═════════════════════════════ AROUND THE NFL (ESPN) ═════════════════════════════ -->
-    {% if espn_news %}
-    <div class="lobby-section section-container mb-6" data-testid="espn-news">
-        <div class="flex items-center gap-3 mb-4">
-            <i class="fas fa-newspaper text-xl text-primary"></i>
-            <h2 class="text-lg font-bold text-text-dark dark:text-white">Around the NFL</h2>
-            <span class="text-xs text-text-secondary-light dark:text-text-secondary">via ESPN</span>
-        </div>
-        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-            {% for article in espn_news %}
-            <a href="{{ article.url }}" target="_blank" rel="noopener noreferrer"
-               class="group flex flex-col overflow-hidden rounded-xl border border-border-light dark:border-border-subtle bg-surface-light dark:bg-surface hover:border-primary/50 hover:shadow-card-hover transition-all">
-                {% if article.image %}
-                <div class="aspect-[16/9] overflow-hidden bg-gray-100 dark:bg-bg-dark/40">
-                    <img src="{{ article.image }}" alt="" loading="lazy"
-                         class="h-full w-full object-cover group-hover:scale-105 transition-transform duration-300"
-                         onerror="this.closest('a').querySelector('.espn-fallback')?.classList.remove('hidden'); this.remove()">
-                </div>
-                {% endif %}
-                <div class="espn-fallback {% if article.image %}hidden{% endif %} flex aspect-[16/9] items-center justify-center bg-gradient-to-br from-primary/10 to-primary/5">
-                    <i class="fas fa-football-ball text-3xl text-primary/40"></i>
-                </div>
-                <div class="p-3 flex-1 flex flex-col">
-                    <p class="text-sm font-bold text-text-dark dark:text-white leading-snug line-clamp-2 group-hover:text-primary transition-colors">{{ article.headline }}</p>
-                    {% if article.description %}
-                    <p class="mt-1 text-xs text-text-secondary-light dark:text-text-secondary line-clamp-2">{{ article.description }}</p>
-                    {% endif %}
-                    <span class="mt-2 inline-flex items-center gap-1 text-[11px] font-semibold text-primary">Read on ESPN <i class="fas fa-arrow-up-right-from-square text-[9px]"></i></span>
-                </div>
-            </a>
-            {% endfor %}
-        </div>
-    </div>
-    {% endif %}
-
     <!-- ═════════════════════════════ MESSAGE BOARD ACTIVITY ════════════════════════════ -->
     <div class="lobby-section section-container mb-6" data-testid="lobby-message-board">
         <div class="flex items-center justify-between gap-3 mb-4">
@@ -473,6 +438,41 @@
         </div>
         {% endif %}
     </div>
+
+    <!-- ═════════════════════════════ AROUND THE NFL (ESPN) ═════════════════════════════ -->
+    {% if espn_news %}
+    <div class="lobby-section section-container mb-6" data-testid="espn-news">
+        <div class="flex items-center gap-3 mb-4">
+            <i class="fas fa-newspaper text-xl text-primary"></i>
+            <h2 class="text-lg font-bold text-text-dark dark:text-white">Around the NFL</h2>
+            <span class="text-xs text-text-secondary-light dark:text-text-secondary">via ESPN</span>
+        </div>
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+            {% for article in espn_news %}
+            <a href="{{ article.url }}" target="_blank" rel="noopener noreferrer"
+               class="group flex flex-col overflow-hidden rounded-xl border border-border-light dark:border-border-subtle bg-surface-light dark:bg-surface hover:border-primary/50 hover:shadow-card-hover transition-all">
+                {% if article.image %}
+                <div class="aspect-[16/9] overflow-hidden bg-gray-100 dark:bg-bg-dark/40">
+                    <img src="{{ article.image }}" alt="" loading="lazy"
+                         class="h-full w-full object-cover group-hover:scale-105 transition-transform duration-300"
+                         onerror="this.closest('a').querySelector('.espn-fallback')?.classList.remove('hidden'); this.remove()">
+                </div>
+                {% endif %}
+                <div class="espn-fallback {% if article.image %}hidden{% endif %} flex aspect-[16/9] items-center justify-center bg-gradient-to-br from-primary/10 to-primary/5">
+                    <i class="fas fa-football-ball text-3xl text-primary/40"></i>
+                </div>
+                <div class="p-3 flex-1 flex flex-col">
+                    <p class="text-sm font-bold text-text-dark dark:text-white leading-snug line-clamp-2 group-hover:text-primary transition-colors">{{ article.headline }}</p>
+                    {% if article.description %}
+                    <p class="mt-1 text-xs text-text-secondary-light dark:text-text-secondary line-clamp-2">{{ article.description }}</p>
+                    {% endif %}
+                    <span class="mt-2 inline-flex items-center gap-1 text-[11px] font-semibold text-primary">Read on ESPN <i class="fas fa-arrow-up-right-from-square text-[9px]"></i></span>
+                </div>
+            </a>
+            {% endfor %}
+        </div>
+    </div>
+    {% endif %}
 
     <!-- ══════════════════════════════════ OWNER ACTIONS ═════════════════════════════════ -->
     <div class="lobby-section flex flex-wrap gap-3 mb-8">

--- a/pickem/pickem_homepage/templates/pickem/family_pool_home.html
+++ b/pickem/pickem_homepage/templates/pickem/family_pool_home.html
@@ -195,11 +195,14 @@
             </a>
         </div>
         {% if week_points_summary %}
-        <div class="grid grid-cols-1 sm:grid-cols-3 gap-3" data-week-points-grid data-week-points-page-size="10">
+        <div class="grid grid-cols-1 sm:grid-cols-3 gap-3" data-week-points-grid data-week-points-page-size="12">
             {% for row in week_points_summary %}
-            <div class="flex items-center justify-between gap-3 rounded-xl border border-border-light dark:border-border-subtle bg-surface-light dark:bg-surface px-4 py-3" data-user-id="{{ row.points.userID }}" data-week-points-row>
+            <div class="flex items-center justify-between gap-3 rounded-xl border border-border-light dark:border-border-subtle bg-surface-light dark:bg-surface px-4 py-3" data-user-id="{{ row.points.userID }}" data-week-points-value="{{ row.week_points }}" data-week-points-row>
                 <div class="flex items-center gap-3 min-w-0">
-                    <span class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-primary/10 text-sm font-black text-primary">#{{ row.rank }}</span>
+                    <span class="w-6 flex-shrink-0 text-center text-sm font-black {% if row.rank %}text-primary{% else %}text-text-secondary-light dark:text-text-secondary{% endif %}">{% if row.rank %}{{ row.rank }}{% else %}<span title="Ranking begins after the first completed game">&ndash;</span>{% endif %}</span>
+                    {% with row.points.userID|lookupavatar as avatar %}
+                    <img src="{{ avatar|default:'https://www.gravatar.com/avatar/?d=identicon&s=64' }}" alt="" class="h-8 w-8 flex-shrink-0 rounded-full border border-border-light dark:border-border-subtle object-cover" onerror="this.src='https://www.gravatar.com/avatar/?d=identicon&s=64'">
+                    {% endwith %}
                     <span class="truncate text-sm font-bold text-text-dark dark:text-white">
                         {% if row.user %}<a href="{% url 'family_pool_user_profile' family.slug pool.slug row.user.id %}" class="hover:text-primary transition-colors">{{ row.user|display_name }}</a>{% else %}Player {{ row.points.userID }}{% endif %}
                     </span>
@@ -672,24 +675,66 @@
         return;
     }
 
+    // Debounced full re-render of the Week Points grid from the server. SSE can
+    // only patch existing text; a reorder or a member who joined after page load
+    // needs fresh server-rendered rows. Coalesces a burst of events into one
+    // fetch; the value patch below still gives instant feedback in the meantime.
+    var refetchTimer = null;
+    function scheduleLeaderboardRefetch() {
+        if (refetchTimer) { clearTimeout(refetchTimer); }
+        refetchTimer = setTimeout(function () {
+            refetchTimer = null;
+            fetch(window.location.href, {
+                headers: { 'X-Requested-With': 'XMLHttpRequest', 'Cache-Control': 'no-store' },
+                cache: 'no-store', credentials: 'same-origin'
+            }).then(function (r) { return r.ok ? r.text() : null; })
+              .then(function (html) {
+                  if (!html) { return; }
+                  var doc = new DOMParser().parseFromString(html, 'text/html');
+                  var fresh = doc.querySelector('[data-week-points-grid]');
+                  var current = document.querySelector('[data-week-points-grid]');
+                  if (fresh && current) {
+                      current.innerHTML = fresh.innerHTML;
+                      if (typeof window.__weekPointsPaginate === 'function') {
+                          window.__weekPointsPaginate();
+                      }
+                  }
+              }).catch(function () {});
+        }, 1500);
+    }
+
     function applyStandingsEvent(ev) {
         var d;
         try { d = JSON.parse(ev.data); } catch (e) { return; }
         if (d.user_id === undefined || d.user_id === null) {
             return;
         }
-        var row = document.querySelector('[data-user-id="' + d.user_id + '"]');
-        if (!row) {
-            return;
-        }
         // week_points is only meaningful for the week this page is showing;
         // an event for a different week (e.g. a late-scoring prior week)
         // must not clobber this podium.
-        if (week && String(d.week) === String(week) && d.week_points !== null && d.week_points !== undefined) {
+        if (!week || String(d.week) !== String(week) ||
+            d.week_points === null || d.week_points === undefined) {
+            return;
+        }
+        // Scope to the Week Points podium rows (the lobby also has standings-
+        // preview rows carrying data-user-id).
+        var row = document.querySelector(
+            '[data-week-points-row][data-user-id="' + d.user_id + '"]');
+        if (!row) {
+            // Member not on the podium yet (joined after load) -> structural.
+            scheduleLeaderboardRefetch();
+            return;
+        }
+        var prev = parseInt(row.getAttribute('data-week-points-value'), 10);
+        if (isNaN(prev) || prev !== d.week_points) {
+            // Patch the value in place for instant feedback...
             var weekPointsEl = row.querySelector('[data-user-week-points]');
             if (weekPointsEl) {
                 weekPointsEl.textContent = d.week_points + ' pts';
             }
+            row.setAttribute('data-week-points-value', d.week_points);
+            // ...then settle row order (and pull in any new rows) via refetch.
+            scheduleLeaderboardRefetch();
         }
     }
 
@@ -724,17 +769,15 @@
      this just shows one page at a time. Hidden past page 1 until navigated. -->
 <script>
 (function () {
-    var grid = document.querySelector('[data-week-points-grid]');
-    if (!grid) { return; }
-    var rows = Array.prototype.slice.call(grid.querySelectorAll('[data-week-points-row]'));
-    var pageSize = parseInt(grid.getAttribute('data-week-points-page-size'), 10) || 10;
     var pager = document.querySelector('[data-week-points-pager]');
-    if (rows.length <= pageSize || !pager) { return; }  // one page: nothing to do
-
-    var prevBtn = pager.querySelector('[data-week-points-prev]');
-    var nextBtn = pager.querySelector('[data-week-points-next]');
-    var label = pager.querySelector('[data-week-points-page-label]');
-    var pageCount = Math.ceil(rows.length / pageSize);
+    var prevBtn = pager ? pager.querySelector('[data-week-points-prev]') : null;
+    var nextBtn = pager ? pager.querySelector('[data-week-points-next]') : null;
+    var label = pager ? pager.querySelector('[data-week-points-page-label]') : null;
+    // Closure state, re-read from the DOM on every refresh() so a live refetch
+    // that swaps the grid's rows re-paginates correctly.
+    var rows = [];
+    var pageSize = 12;
+    var pageCount = 1;
     var page = 0;
 
     function render() {
@@ -748,11 +791,29 @@
         if (nextBtn) { nextBtn.disabled = (page >= pageCount - 1); }
     }
 
+    function refresh() {
+        var grid = document.querySelector('[data-week-points-grid]');
+        if (!grid) { return; }
+        rows = Array.prototype.slice.call(grid.querySelectorAll('[data-week-points-row]'));
+        pageSize = parseInt(grid.getAttribute('data-week-points-page-size'), 10) || 12;
+        pageCount = Math.max(1, Math.ceil(rows.length / pageSize));
+        if (page >= pageCount) { page = pageCount - 1; }
+        if (!pager || rows.length <= pageSize) {  // one page: show all, hide pager
+            rows.forEach(function (row) { row.classList.remove('hidden'); });
+            if (pager) { pager.classList.add('hidden'); }
+            return;
+        }
+        pager.classList.remove('hidden');
+        render();
+    }
+
+    // Buttons live outside the grid, so their listeners survive a grid innerHTML
+    // swap — bind them once here; render() reads the refreshed closure state.
     if (prevBtn) { prevBtn.addEventListener('click', function () { if (page > 0) { page--; render(); } }); }
     if (nextBtn) { nextBtn.addEventListener('click', function () { if (page < pageCount - 1) { page++; render(); } }); }
 
-    pager.classList.remove('hidden');
-    render();
+    window.__weekPointsPaginate = refresh;  // re-init hook for the live refetch
+    refresh();
 })();
 </script>
 {% endblock %}

--- a/pickem/pickem_homepage/templates/pickem/standings.html
+++ b/pickem/pickem_homepage/templates/pickem/standings.html
@@ -133,12 +133,13 @@
         </div>
 
         <!-- Leaderboard -->
-        <div class="space-y-1.5 p-3">
+        <div class="space-y-1.5 p-3" data-standings-list>
             {% for player in player_points %}
             <a href="{% if family and pool %}{% url 'family_pool_user_profile' family.slug pool.slug player.userID %}{% else %}{% url 'user_profile' player.userID %}{% endif %}"
                class="standings-row block bg-white/60 dark:bg-bg-dark/30 rounded-lg px-3 py-2 border border-border-light dark:border-border-subtle hover:border-primary/50 dark:hover:border-primary/50 hover:shadow-card-hover transition-all duration-200"
                style="animation-delay: {{ forloop.counter0|add:1|floatformat:2 }}s"
-               data-user-id="{{ player.userID }}">
+               data-user-id="{{ player.userID }}"
+               data-total-points="{{ player.total_points|default:0 }}">
                 {% with usernames|lookup:player.userID as username %}
                 {% with avatars|lookup:player.userID as avatar %}
 
@@ -367,22 +368,57 @@ document.addEventListener('DOMContentLoaded', function () {
         return;
     }
 
+    // Debounced full re-render of the leaderboard from the server. SSE can only
+    // patch existing text; a reorder (or a member who joined after page load)
+    // needs fresh server-ordered rows. Coalesces a burst into one fetch; the
+    // in-place patch below still gives instant feedback in the meantime.
+    var refetchTimer = null;
+    function scheduleLeaderboardRefetch() {
+        if (refetchTimer) { clearTimeout(refetchTimer); }
+        refetchTimer = setTimeout(function () {
+            refetchTimer = null;
+            fetch(window.location.href, {
+                headers: { 'X-Requested-With': 'XMLHttpRequest', 'Cache-Control': 'no-store' },
+                cache: 'no-store', credentials: 'same-origin'
+            }).then(function (r) { return r.ok ? r.text() : null; })
+              .then(function (html) {
+                  if (!html) { return; }
+                  var doc = new DOMParser().parseFromString(html, 'text/html');
+                  var fresh = doc.querySelector('[data-standings-list]');
+                  var current = document.querySelector('[data-standings-list]');
+                  if (fresh && current) {
+                      current.innerHTML = fresh.innerHTML;
+                  }
+              }).catch(function () {});
+        }, 1500);
+    }
+
     function applyStandingsEvent(ev) {
         var d;
         try { d = JSON.parse(ev.data); } catch (e) { return; }
         if (d.user_id === undefined || d.user_id === null) {
             return;
         }
-        var row = document.querySelector('[data-user-id="' + d.user_id + '"]');
-        if (!row) {
-            return;
-        }
         if (d.total_points === null || d.total_points === undefined) {
             return;
         }
-        var totalPointsEl = row.querySelector('[data-user-total-points]');
-        if (totalPointsEl) {
-            totalPointsEl.textContent = d.total_points;
+        var row = document.querySelector(
+            '.standings-row[data-user-id="' + d.user_id + '"]');
+        if (!row) {
+            // Member not on the leaderboard yet (joined after load) -> structural.
+            scheduleLeaderboardRefetch();
+            return;
+        }
+        var prev = parseInt(row.getAttribute('data-total-points'), 10);
+        if (isNaN(prev) || prev !== d.total_points) {
+            // Patch the value in place for instant feedback...
+            var totalPointsEl = row.querySelector('[data-user-total-points]');
+            if (totalPointsEl) {
+                totalPointsEl.textContent = d.total_points;
+            }
+            row.setAttribute('data-total-points', d.total_points);
+            // ...then settle row order (and pull in any new rows) via refetch.
+            scheduleLeaderboardRefetch();
         }
     }
 

--- a/pickem/pickem_homepage/templates/pickem/standings.html
+++ b/pickem/pickem_homepage/templates/pickem/standings.html
@@ -373,7 +373,12 @@ document.addEventListener('DOMContentLoaded', function () {
     // needs fresh server-ordered rows. Coalesces a burst into one fetch; the
     // in-place patch below still gives instant feedback in the meantime.
     var refetchTimer = null;
+    var refetchGeneration = 0;
     function scheduleLeaderboardRefetch() {
+        // Bump a generation token each schedule; an in-flight fetch that resolves
+        // out of order (a slower older request finishing after a newer one) is
+        // discarded so it can't overwrite fresher rows with stale HTML.
+        var generation = ++refetchGeneration;
         if (refetchTimer) { clearTimeout(refetchTimer); }
         refetchTimer = setTimeout(function () {
             refetchTimer = null;
@@ -382,7 +387,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 cache: 'no-store', credentials: 'same-origin'
             }).then(function (r) { return r.ok ? r.text() : null; })
               .then(function (html) {
-                  if (!html) { return; }
+                  if (!html || generation !== refetchGeneration) { return; }
                   var doc = new DOMParser().parseFromString(html, 'text/html');
                   var fresh = doc.querySelector('[data-standings-list]');
                   var current = document.querySelector('[data-standings-list]');

--- a/pickem/pickem_homepage/tests.py
+++ b/pickem/pickem_homepage/tests.py
@@ -586,7 +586,12 @@ class TenantDashboardIsolationTests(TestCase):
         self.assertEqual(lobby.status_code, 200)
         self.assertContains(lobby, "data-week-points-grid")
         self.assertContains(lobby, 'data-week-points-page-size="12"')
-        self.assertContains(lobby, 'data-week-points-value="3"')
+        # The row-identity hook (data-user-id) must sit on the same row as the
+        # reorder value attr — the SSE client finds the row by data-user-id.
+        self.assertRegex(
+            lobby.content.decode(),
+            rf'data-user-id="{self.member.id}"\s+data-week-points-value="3"',
+        )
         self.assertContains(lobby, "__weekPointsPaginate")
 
         # Standings leaderboard: container hook + per-row reorder value attr.
@@ -596,7 +601,10 @@ class TenantDashboardIsolationTests(TestCase):
         ))
         self.assertEqual(standings.status_code, 200)
         self.assertContains(standings, "data-standings-list")
-        self.assertContains(standings, 'data-total-points="3"')
+        self.assertRegex(
+            standings.content.decode(),
+            rf'data-user-id="{self.member.id}"\s+data-total-points="3"',
+        )
         self.assertContains(standings, "data-user-total-points")
 
     def test_pool_home_is_branded_as_lobby_with_gsap_polish(self):

--- a/pickem/pickem_homepage/tests.py
+++ b/pickem/pickem_homepage/tests.py
@@ -568,6 +568,37 @@ class TenantDashboardIsolationTests(TestCase):
         games_heading = response.context["games_section_heading"]
         self.assertLess(content.index("Week Points"), content.index(games_heading))
 
+    def test_live_update_dom_contract_present_on_lobby_and_standings(self):
+        """Lock the data-* hooks the SSE clients depend on so a template change
+        can't silently break structural live updates (#159)."""
+        family, pool = self._family_with_pool("Smith Family", "smith-family")
+        self._active_membership(self.member, family)
+        userSeasonPoints.objects.create(
+            pool=pool, userEmail=self.member.email, userID=str(self.member.id),
+            gameseason=2526, gameyear="2025", week_1_points=3, total_points=3,
+        )
+        self.client.force_login(self.member)
+
+        # Lobby Week Points block: grid hook, page size 12, per-row value attr
+        # (asserted with its value so it matches a rendered row, not the JS
+        # literal), and the pagination re-init hook the refetch calls.
+        lobby = self.client.get(self._tenant_url(family, pool))
+        self.assertEqual(lobby.status_code, 200)
+        self.assertContains(lobby, "data-week-points-grid")
+        self.assertContains(lobby, 'data-week-points-page-size="12"')
+        self.assertContains(lobby, 'data-week-points-value="3"')
+        self.assertContains(lobby, "__weekPointsPaginate")
+
+        # Standings leaderboard: container hook + per-row reorder value attr.
+        standings = self.client.get(reverse(
+            "family_pool_standings",
+            kwargs={"family_slug": family.slug, "pool_slug": pool.slug},
+        ))
+        self.assertEqual(standings.status_code, 200)
+        self.assertContains(standings, "data-standings-list")
+        self.assertContains(standings, 'data-total-points="3"')
+        self.assertContains(standings, "data-user-total-points")
+
     def test_pool_home_is_branded_as_lobby_with_gsap_polish(self):
         smith_family, smith_pool = self._family_with_pool("Smith Family", "smith-family")
         smith_pool.season = 2627

--- a/pickem/pickem_homepage/tests.py
+++ b/pickem/pickem_homepage/tests.py
@@ -9615,23 +9615,37 @@ class BuildWeekPointsSummaryTests(TestCase):
         )
         return user
 
-    def test_includes_all_members_at_zero_before_any_scoring(self):
+    def test_includes_all_members_but_unranked_before_any_completed_game(self):
         from pickem_homepage.views import build_week_points_summary
         # Two members whose week points are still null (nothing scored yet).
         u1 = self._member("alice", None)
         u2 = self._member("bob", None)
-        summary = build_week_points_summary(self.pool, self.season, "1")
+        # No game completed yet -> everyone equal -> no rank (shown as "-").
+        summary = build_week_points_summary(
+            self.pool, self.season, "1", week_has_completed_game=False
+        )
         self.assertEqual(len(summary), 2)  # all members shown, not an empty podium
         self.assertEqual({row['week_points'] for row in summary}, {0})  # null -> 0
-        self.assertEqual([row['rank'] for row in summary], [1, 2])
+        self.assertEqual([row['rank'] for row in summary], [None, None])
         self.assertEqual({row['user'].id for row in summary}, {u1.id, u2.id})
+
+    def test_rank_is_numeric_once_a_game_has_completed(self):
+        from pickem_homepage.views import build_week_points_summary
+        self._member("alice", None)
+        self._member("bob", None)
+        summary = build_week_points_summary(
+            self.pool, self.season, "1", week_has_completed_game=True
+        )
+        self.assertEqual([row['rank'] for row in summary], [1, 2])
 
     def test_orders_by_week_points_desc_treating_null_as_zero(self):
         from pickem_homepage.views import build_week_points_summary
         leader = self._member("leader", 7)
         self._member("null_member", None)   # must sort as 0, not nulls-first
         self._member("zero_member", 0)
-        summary = build_week_points_summary(self.pool, self.season, "1")
+        summary = build_week_points_summary(
+            self.pool, self.season, "1", week_has_completed_game=True
+        )
         self.assertEqual(summary[0]['user'].id, leader.id)   # 7 pts ranks first
         self.assertEqual(summary[0]['rank'], 1)
         self.assertEqual([row['week_points'] for row in summary], [7, 0, 0])
@@ -9639,9 +9653,12 @@ class BuildWeekPointsSummaryTests(TestCase):
     def test_out_of_range_week_returns_empty(self):
         from pickem_homepage.views import build_week_points_summary
         self._member("alice", 3)
-        self.assertEqual(build_week_points_summary(self.pool, self.season, "0"), [])
-        self.assertEqual(build_week_points_summary(self.pool, self.season, "19"), [])
-        self.assertEqual(build_week_points_summary(self.pool, self.season, "x"), [])
+        self.assertEqual(
+            build_week_points_summary(self.pool, self.season, "0", week_has_completed_game=True), [])
+        self.assertEqual(
+            build_week_points_summary(self.pool, self.season, "19", week_has_completed_game=True), [])
+        self.assertEqual(
+            build_week_points_summary(self.pool, self.season, "x", week_has_completed_game=True), [])
 
     def test_tied_scores_break_by_numeric_user_id(self):
         # userID is stored as str(user.id); tied week scores must order 2 before
@@ -9654,6 +9671,8 @@ class BuildWeekPointsSummaryTests(TestCase):
                 pool=self.pool, userEmail=f"u{uid}@ex.com", userID=str(user.id),
                 gameseason=self.season, gameyear="2025", week_1_points=0,
             )
-        summary = build_week_points_summary(self.pool, self.season, "1")
+        summary = build_week_points_summary(
+            self.pool, self.season, "1", week_has_completed_game=True
+        )
         ordered_ids = [row['points'].userID for row in summary]
         self.assertEqual(ordered_ids, ["2", "10"])  # numeric, not lexicographic

--- a/pickem/pickem_homepage/views.py
+++ b/pickem/pickem_homepage/views.py
@@ -460,7 +460,7 @@ def get_current_week_context(gameseason):
         return '1', 'nfl'
 
 
-def build_week_points_summary(pool, gameseason, current_week):
+def build_week_points_summary(pool, gameseason, current_week, week_has_completed_game):
     """Ordered week-points rows for every member of ``pool`` this season.
 
     Week points default to 0 (a null ``week_N_points`` is coalesced to 0), so an
@@ -469,6 +469,10 @@ def build_week_points_summary(pool, gameseason, current_week):
     member also keeps their ``data-user-id`` rows on the lobby so the live SSE
     update (Phase 3c) can patch points in place from kickoff; the template
     paginates the list client-side. Ordered by week points desc, then userID.
+
+    ``rank`` is a number (1..N) only when ``week_has_completed_game`` is True;
+    before the week's first game completes everyone is equal, so ``rank`` is
+    ``None`` and the template shows a dash instead of a position.
     Returns ``[]`` when ``current_week`` is not a valid week number (1-18).
     """
     if not (str(current_week).isdigit() and 1 <= int(current_week) <= 18):
@@ -498,7 +502,7 @@ def build_week_points_summary(pool, gameseason, current_week):
     week_points_users = User.objects.in_bulk(week_points_user_ids)
     return [
         {
-            'rank': rank,
+            'rank': (rank if week_has_completed_game else None),
             'points': points,
             'week_points': getattr(points, week_points_field) or 0,
             'user': week_points_users.get(int(points.userID)) if str(points.userID).isdigit() else None,
@@ -1145,8 +1149,18 @@ def family_pool_home(request, family_slug, pool_slug):
     ]
 
     # Every pool member's week points — 0 to start, all members shown; the
-    # template paginates client-side. See build_week_points_summary().
-    week_points_summary = build_week_points_summary(pool, gameseason, current_week)
+    # template paginates client-side. See build_week_points_summary(). Ranks are
+    # hidden until this week has a scored game (before that everyone is at 0 and
+    # equal), mirroring the season-wide season_has_started treatment above.
+    week_has_completed_game = GamesAndScores.objects.filter(
+        gameseason=gameseason,
+        competition=current_competition,
+        gameWeek=current_week,
+        gameScored=True,
+    ).exists()
+    week_points_summary = build_week_points_summary(
+        pool, gameseason, current_week, week_has_completed_game
+    )
 
     recent_winners = []
     for week_num in range(1, 19):


### PR DESCRIPTION
## What & why

Completes the live-updates initiative's structural gap (#159): the SSE clients could only patch existing DOM text, so leaderboard **reorder** and **newly-joined rows** still needed a manual reload. Also bundles the small lobby tweaks requested alongside it.

### Live structural updates (#159)
- **Lobby Week Points** and **/standings/** now re-render their leaderboard live on a **reorder** or a **member who joined after page load**, via a debounced (1.5s, coalesced) server refetch that swaps just the leaderboard container. The instant in-place value patch stays for immediate feedback; the refetch settles order.
- Reorder is detected by comparing the incoming value against a new per-row value attribute (`data-week-points-value` / `data-total-points`).
- Lobby pagination reworked to be **idempotent** and exposes `window.__weekPointsPaginate` so the refetch can re-init it after swapping rows.
- **Scores kickoff/finish swap (§2) was already working** end-to-end via SSE (`statusType` is a publish trigger → `applyScoreEvent` forces a full card refetch). No change needed; the demo "didn't swap" only because the DB was edited directly, bypassing `update_games`/publish.

### Week Points block polish (lobby)
- **Rank hidden until the week has a completed game** — before then everyone is at 0 and equal, so rows show `–` (mirrors the existing season-wide standings-preview treatment). Numeric `#N` once a game is scored.
- **User avatars** in each row (like the scores page), via `lookupavatar`.
- **Paginate at 12** (3×4 grid) instead of 10.

### Message Board 1-off
- Moves the **Message Board** section above **Around the NFL** on the lobby.

## Deferred to #160
- Scores pre-kickoff heartbeat fallback (§4) — only guards the rare "SSE fully down at the exact kickoff second" edge; not worth a fragile time-based poll now.

## Testing
- New `build_week_points_summary` rank-rule tests (rank `None` with no completed game; `1..N` after).
- New DOM-contract test locking the `data-*` hooks the SSE clients depend on (lobby + standings).
- Full suite: **932 passed** (`--settings=pickem.test_settings`). No migrations, no server behavior changes, no Tailwind churn.

Spec: `docs/superpowers/specs/2026-08-03-structural-live-updates-design.md`
Plan: `docs/superpowers/plans/2026-08-03-structural-live-updates.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live leaderboard updates for lobby and standings pages, including reordered and newly added entries.
  * Week Points rankings now appear after a completed game; unranked players display an em dash.
  * Added player avatars and increased leaderboard pagination to 12 entries per page.
  * Improved live score and points updates with immediate value changes and automatic refreshes.

* **Bug Fixes**
  * Improved pagination behavior after leaderboard updates and when fewer entries are available.
  * Added handling for missing or invalid live-update entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->