### PR TITLE
fix(lobby): refresh ScrollTrigger after Week Points pagination

### DIFF
--- a/pickem/pickem_homepage/templates/pickem/family_pool_home.html
+++ b/pickem/pickem_homepage/templates/pickem/family_pool_home.html
@@ -794,6 +794,12 @@
         if (label) { label.textContent = 'Page ' + (page + 1) + ' of ' + pageCount; }
         if (prevBtn) { prevBtn.disabled = (page === 0); }
         if (nextBtn) { nextBtn.disabled = (page >= pageCount - 1); }
+        // Toggling row display:none changes document height, shifting every
+        // section below Week Points. The GSAP reveal ScrollTriggers cache their
+        // positions and don't re-evaluate on a display change (no scroll/resize
+        // fires), so a section still below the fold (e.g. "Upcoming" games) would
+        // stay stuck at autoAlpha:0. Recompute positions so it reveals in place.
+        window.ScrollTrigger && window.ScrollTrigger.refresh();
     }
 
     function refresh() {

--- a/pickem/pickem_homepage/tests.py
+++ b/pickem/pickem_homepage/tests.py
@@ -607,6 +607,26 @@ class TenantDashboardIsolationTests(TestCase):
         )
         self.assertContains(standings, "data-user-total-points")
 
+    def test_week_points_pagination_refreshes_scroll_reveal(self):
+        """Paginating Week Points toggles row display, which shifts every
+        section below it. The GSAP reveal caches trigger positions at load, so
+        without a ScrollTrigger.refresh() after a page change the "Upcoming"
+        games section — held at autoAlpha:0 while below the fold — never fires
+        and stays hidden. Lock the guarded refresh into the pager (bug: games
+        tiles fail to render on Week Points pages past page 1)."""
+        family, pool = self._family_with_pool("Smith Family", "smith-family")
+        self._active_membership(self.member, family)
+        userSeasonPoints.objects.create(
+            pool=pool, userEmail=self.member.email, userID=str(self.member.id),
+            gameseason=2526, gameyear="2025", week_1_points=3, total_points=3,
+        )
+        self.client.force_login(self.member)
+
+        lobby = self.client.get(self._tenant_url(family, pool)).content.decode()
+        # The pager's render() must recompute stale ScrollTrigger positions
+        # after it changes row visibility, guarded for reduced-motion / no-GSAP.
+        self.assertRegex(lobby, r"window\.ScrollTrigger\s*&&\s*window\.ScrollTrigger\.refresh\(\)")
+
     def test_pool_home_is_branded_as_lobby_with_gsap_polish(self):
         smith_family, smith_pool = self._family_with_pool("Smith Family", "smith-family")
         smith_pool.season = 2627

--- a/pickem/pickem_homepage/tests.py
+++ b/pickem/pickem_homepage/tests.py
@@ -612,20 +612,31 @@ class TenantDashboardIsolationTests(TestCase):
         section below it. The GSAP reveal caches trigger positions at load, so
         without a ScrollTrigger.refresh() after a page change the "Upcoming"
         games section — held at autoAlpha:0 while below the fold — never fires
-        and stays hidden. Lock the guarded refresh into the pager (bug: games
-        tiles fail to render on Week Points pages past page 1)."""
+        and stays hidden. Lock the guarded refresh into the pager's render()
+        (bug: games tiles fail to render on Week Points pages past page 1)."""
         family, pool = self._family_with_pool("Smith Family", "smith-family")
         self._active_membership(self.member, family)
-        userSeasonPoints.objects.create(
-            pool=pool, userEmail=self.member.email, userID=str(self.member.id),
-            gameseason=2526, gameyear="2025", week_1_points=3, total_points=3,
-        )
+        # Seed more than one page (page size is 12) so the pager is actually
+        # active — the bug only manifests when a page change toggles rows.
+        season = get_season()
+        for i in range(13):
+            userSeasonPoints.objects.create(
+                pool=pool, userEmail=f"wp{i}@example.com", userID=str(1000 + i),
+                gameseason=season, gameyear=str(2000 + season // 100),
+                week_1_points=i, total_points=i,
+            )
         self.client.force_login(self.member)
 
-        lobby = self.client.get(self._tenant_url(family, pool)).content.decode()
-        # The pager's render() must recompute stale ScrollTrigger positions
-        # after it changes row visibility, guarded for reduced-motion / no-GSAP.
-        self.assertRegex(lobby, r"window\.ScrollTrigger\s*&&\s*window\.ScrollTrigger\.refresh\(\)")
+        html = self.client.get(self._tenant_url(family, pool)).content.decode()
+        # Every seeded member renders a row (data-week-points-value="…" appears
+        # only on rows; the JS references the attr with single quotes), so 13
+        # rows means the client-side pager spans more than one page.
+        self.assertEqual(html.count('data-week-points-value="'), 13)
+        # The refresh must live *inside* the pager's render(), after it toggles
+        # row visibility — not merely somewhere on the page — and be guarded for
+        # reduced-motion / no-GSAP.
+        render_body = html.split("function render()", 1)[1].split("function refresh()", 1)[0]
+        self.assertRegex(render_body, r"window\.ScrollTrigger\s*&&\s*window\.ScrollTrigger\.refresh\(\)")
 
     def test_pool_home_is_branded_as_lobby_with_gsap_polish(self):
         smith_family, smith_pool = self._family_with_pool("Smith Family", "smith-family")


### PR DESCRIPTION
## Problem

On the Lobby page, navigating the **Week Points** pager to any page past page 1 left the **"Upcoming: Week x"** games tiles stuck hidden / half-rendered (only the top tile showed). Page 1 was unaffected.

## Root cause

The GSAP `ScrollTrigger` reveal in `family_pool_home.html` runs `gsap.from(section, {autoAlpha:0, y:24})` on every `.lobby-section` and **caches each section's scroll position at page load**. With Week Points on page 1 (full 12 rows), the games section sits below the fold, held at `autoAlpha:0`, waiting for its trigger.

The client-side pager toggles `.hidden` (`display:none`) on rows, which shrinks the page and slides the games section into view — but a `display` change fires **no scroll or resize event**, so ScrollTrigger never recomputes and the section stays stuck in its hidden `from` state. Page 1 worked because normal scrolling fires the trigger the ordinary way. Nothing in the file called `ScrollTrigger.refresh()`.

## Fix

After the pager's `render()` changes row visibility, call `window.ScrollTrigger && window.ScrollTrigger.refresh()` so stale trigger positions recompute and the now-in-view games section reveals in place. The guard makes it a safe no-op under reduced-motion or when GSAP didn't load.

## Test

Adds `test_week_points_pagination_refreshes_scroll_reveal` (in `TenantDashboardIsolationTests`), following the repo's existing DOM-contract pattern — red before the fix, green after. Full suite (933 tests) passes; `npm run build:prod` produced no CSS churn (JS-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed Week Points pagination to properly refresh scroll positions when toggling row visibility, ensuring sections below the fold recalculate their positions correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->