### PR TITLE
fix: eliminate live-update flashing + wire lobby game tiles to live scores

### DIFF
--- a/docs/superpowers/specs/2026-08-06-lobby-live-update-no-flash-design.md
+++ b/docs/superpowers/specs/2026-08-06-lobby-live-update-no-flash-design.md
@@ -1,0 +1,88 @@
+# Lobby Live-Update: Stop the Flash — Design
+
+**Date:** 2026-08-06
+**Status:** Approved (brainstorming) — implement directly (small single-file JS change)
+**Feature:** #159 live-update lobby (`family_pool_home.html`), not the simulation harness.
+**Found by:** the live-weekend simulation harness demo (watching real SSE updates).
+
+## Problem
+
+On the lobby, the **Week Points** panel updates live via SSE. On every standings
+event (debounced 1.5s) the handler does a **full `innerHTML` replace of the whole
+tile grid**:
+
+```js
+current.innerHTML = fresh.innerHTML;   // family_pool_home.html ~line 702
+```
+
+This tears down and recreates **every** tile's DOM node, even tiles whose data
+did not change — the browser repaints the entire panel, which reads as a flash.
+During scoring this fires constantly. User feedback: "the other cards updating
+almost gave me a seizure." (The row *reorder* itself is fine to animate subtly;
+it's the wholesale redraw of unchanged tiles that's the problem.)
+
+A secondary path: the pager's `render()` calls a global `ScrollTrigger.refresh()`
+(~line 802) which, in pools large enough to paginate (>12 members), can re-fire
+the GSAP `from()` reveal on other lobby sections. In small pools the pager's
+one-page early-return means `refresh()` isn't called, so the primary cause there
+is purely the `innerHTML` teardown.
+
+## Fix
+
+Two parts, both in `family_pool_home.html` (client-side JS only):
+
+### 1. In-place keyed reconcile (removes the flash)
+
+Replace the wholesale `innerHTML` swap with a reconcile that **reuses existing
+tile nodes**, keyed by `data-user-id`:
+
+- Still fetch the server-rendered rows as the source of truth (correct order,
+  ranks, new/removed members).
+- For an existing member: patch the node's content **only if** its rendered HTML
+  actually changed (`node.innerHTML !== fresh.innerHTML`); update its
+  `data-week-points-value`. Unchanged tiles are never touched → no repaint.
+- Reorder by **moving** existing nodes into server order (`appendChild` moves,
+  it doesn't recreate) — so a rank change relocates a tile without a teardown.
+- Add only genuinely new member nodes; remove only departed ones. These count as
+  a **structural** change.
+- Animate moved tiles with a subtle **FLIP** slide (~220ms): record positions
+  before the moves, then transition each moved node from its old offset to 0.
+  Respect `prefers-reduced-motion` (snap instantly). Skip nodes that are hidden
+  (0-width) so paginated-away rows don't animate.
+
+### 2. Gate the pager's `ScrollTrigger.refresh()` (defensive, for >12-member pools)
+
+Thread a `skipScrollRefresh` flag through the pager's `refresh()`/`render()`.
+The live-update path calls the pager with `skipScrollRefresh = !structural`: a
+pure value/reorder update leaves the visible-row count (and thus page height)
+unchanged, so no `ScrollTrigger.refresh()` fires and the other lobby sections
+stay perfectly still. A structural change (member added/removed, which can shift
+height) still refreshes. **Manual page-nav (prev/next) keeps its refresh**, since
+that genuinely changes which/how-many rows show.
+
+## Non-goals
+
+- No change to the SSE transport, the server-rendered row template, or the
+  server publish path.
+- Keep the existing instant value-patch (`applyStandingsEvent`) — it gives
+  immediate feedback before the debounced reconcile; the reconcile then just
+  confirms order against server truth without flashing.
+- The initial page-load reveal animation is unchanged (it should still run once).
+
+## Verification
+
+There is **no JS test runner** in this repo, so:
+
+1. The existing Django "live-update DOM contract" test (`pickem_homepage`
+   tests) must stay green — it asserts the `data-week-points-row` /
+   `data-user-id` / `data-week-points-value` / `data-user-week-points`
+   attributes the reconcile depends on still render.
+2. **Live verification on the running `:8055` demo**: run a weekend simulation
+   and confirm (a) unchanged tiles no longer flash, (b) a rank change slides
+   its tile subtly, (c) the other lobby cards do not animate on updates.
+
+## Branch
+
+Own branch off the lobby base (`5e73c24`, tip of
+`fix/lobby-scrolltrigger-pagination-refresh`) — kept separate from the
+`feature/live-weekend-simulation` harness branch.

--- a/pickem/pickem_homepage/templates/pickem/family_pool_home.html
+++ b/pickem/pickem_homepage/templates/pickem/family_pool_home.html
@@ -681,6 +681,90 @@
     // fetch; the value patch below still gives instant feedback in the meantime.
     var refetchTimer = null;
     var refetchGeneration = 0;
+
+    // Reconcile the Week Points tiles in place against freshly server-rendered
+    // rows, reusing existing tile nodes keyed by data-user-id. The old code
+    // replaced the whole grid's innerHTML on every event, which tore down and
+    // repainted EVERY tile (even unchanged ones) — a constant full-panel flash
+    // during scoring. Here, unchanged tiles are never touched; only changed
+    // tiles patch, and rank changes relocate a tile with a subtle FLIP slide.
+    // Returns true if the member set changed (rows added/removed) — a structural
+    // change the pager must fully re-evaluate (it can shift page height).
+    function reconcileWeekPoints(current, fresh) {
+        var reduce = window.matchMedia &&
+            window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        var freshRows = Array.prototype.slice.call(
+            fresh.querySelectorAll('[data-week-points-row]'));
+        var currentRows = Array.prototype.slice.call(
+            current.querySelectorAll('[data-week-points-row]'));
+        var byId = {};
+        currentRows.forEach(function (r) {
+            byId[r.getAttribute('data-user-id')] = r;
+        });
+
+        // FLIP step 1: record current positions before any DOM move.
+        var firstRects = {};
+        if (!reduce) {
+            currentRows.forEach(function (r) {
+                firstRects[r.getAttribute('data-user-id')] =
+                    r.getBoundingClientRect();
+            });
+        }
+
+        var structural = false;
+        var seen = {};
+        // Walk fresh order; append each matching node (existing or new) so the
+        // grid ends in server order without recreating unchanged nodes.
+        freshRows.forEach(function (freshRow) {
+            var id = freshRow.getAttribute('data-user-id');
+            seen[id] = true;
+            var node = byId[id];
+            if (node) {
+                if (node.innerHTML !== freshRow.innerHTML) {
+                    node.innerHTML = freshRow.innerHTML;  // only changed tiles
+                }
+                node.setAttribute('data-week-points-value',
+                    freshRow.getAttribute('data-week-points-value'));
+            } else {
+                node = document.importNode(freshRow, true);  // new member
+                structural = true;
+            }
+            current.appendChild(node);  // moving an existing node keeps it alive
+        });
+        // Remove members no longer present.
+        currentRows.forEach(function (r) {
+            if (!seen[r.getAttribute('data-user-id')]) {
+                r.parentNode && r.parentNode.removeChild(r);
+                structural = true;
+            }
+        });
+
+        // FLIP step 2: slide any tile that moved from its old position. Skip
+        // hidden (paginated-away) rows, which measure as zero-size.
+        if (!reduce) {
+            currentRows.forEach(function (node) {
+                var first = firstRects[node.getAttribute('data-user-id')];
+                if (!first || !first.width || !node.parentNode) { return; }
+                var last = node.getBoundingClientRect();
+                if (!last.width) { return; }
+                var dx = first.left - last.left;
+                var dy = first.top - last.top;
+                if (dx === 0 && dy === 0) { return; }
+                node.style.transition = 'none';
+                node.style.transform = 'translate(' + dx + 'px,' + dy + 'px)';
+                requestAnimationFrame(function () {
+                    node.style.transition = 'transform 220ms ease';
+                    node.style.transform = '';
+                });
+                window.setTimeout(function () {
+                    node.style.transition = '';
+                    node.style.transform = '';
+                }, 260);
+            });
+        }
+        return structural;
+    }
+
     function scheduleLeaderboardRefetch() {
         // Bump a generation token each schedule; an in-flight fetch that resolves
         // out of order (a slower older request finishing after a newer one) is
@@ -699,9 +783,12 @@
                   var fresh = doc.querySelector('[data-week-points-grid]');
                   var current = document.querySelector('[data-week-points-grid]');
                   if (fresh && current) {
-                      current.innerHTML = fresh.innerHTML;
+                      var structural = reconcileWeekPoints(current, fresh);
                       if (typeof window.__weekPointsPaginate === 'function') {
-                          window.__weekPointsPaginate();
+                          // Re-paginate; only let it refresh ScrollTriggers (which
+                          // would re-animate other sections) when the member set
+                          // actually changed — a pure reorder leaves height alone.
+                          window.__weekPointsPaginate(!structural);
                       }
                   }
               }).catch(function () {});
@@ -785,7 +872,7 @@
     var pageCount = 1;
     var page = 0;
 
-    function render() {
+    function render(skipScrollRefresh) {
         var start = page * pageSize;
         var end = start + pageSize;
         rows.forEach(function (row, i) {
@@ -799,10 +886,16 @@
         // positions and don't re-evaluate on a display change (no scroll/resize
         // fires), so a section still below the fold (e.g. "Upcoming" games) would
         // stay stuck at autoAlpha:0. Recompute positions so it reveals in place.
-        window.ScrollTrigger && window.ScrollTrigger.refresh();
+        // BUT refreshing also re-fires those from() reveals on already-visible
+        // sections (a jarring flash). A live reorder doesn't change height, so
+        // the live-update path passes skipScrollRefresh=true to leave other
+        // sections untouched; manual page-nav (height changes) still refreshes.
+        if (!skipScrollRefresh) {
+            window.ScrollTrigger && window.ScrollTrigger.refresh();
+        }
     }
 
-    function refresh() {
+    function refresh(skipScrollRefresh) {
         var grid = document.querySelector('[data-week-points-grid]');
         if (!grid) { return; }
         rows = Array.prototype.slice.call(grid.querySelectorAll('[data-week-points-row]'));
@@ -815,7 +908,7 @@
             return;
         }
         pager.classList.remove('hidden');
-        render();
+        render(skipScrollRefresh);
     }
 
     // Buttons live outside the grid, so their listeners survive a grid innerHTML

--- a/pickem/pickem_homepage/templates/pickem/family_pool_home.html
+++ b/pickem/pickem_homepage/templates/pickem/family_pool_home.html
@@ -791,7 +791,13 @@
                           window.__weekPointsPaginate(!structural);
                       }
                   }
-              }).catch(function () {});
+              }).catch(function (err) {
+                  // Best-effort: a dropped fetch just stops live reordering
+                  // until reload. Log so a genuine bug in reconcileWeekPoints
+                  // (the ~70 lines of DOM surgery above) is distinguishable
+                  // from a routine network blip rather than silently vanishing.
+                  if (window.console) { console.error('week points live refetch/reconcile failed', err); }
+              });
         }, 1500);
     }
 
@@ -901,7 +907,12 @@
                               fresh.getAttribute('data-game-status'));
                       }
                   });
-              }).catch(function () {});
+              }).catch(function (err) {
+                  // Best-effort (see the standings refetch above): log so a real
+                  // bug in this refetch/reconcile is distinguishable from a
+                  // routine network blip rather than silently disappearing.
+                  if (window.console) { console.error('lobby games live refetch failed', err); }
+              });
         }, 1200);
     }
 

--- a/pickem/pickem_homepage/templates/pickem/family_pool_home.html
+++ b/pickem/pickem_homepage/templates/pickem/family_pool_home.html
@@ -246,16 +246,16 @@
             </a>
         </div>
         {% if current_week_games %}
-        <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
+        <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3" data-lobby-games-grid>
             {% for game in current_week_games %}
-            <div class="lobby-live-card rounded-xl border border-border-light dark:border-border-subtle bg-surface-light dark:bg-surface p-4">
+            <div class="lobby-live-card rounded-xl border border-border-light dark:border-border-subtle bg-surface-light dark:bg-surface p-4" data-lobby-game-card data-game-id="{{ game.id }}" data-game-status="{{ game.statusType|lower }}">
                 <div class="flex items-center justify-between gap-3 mb-3">
                     <span class="inline-flex items-center gap-2 rounded-full px-2.5 py-1 text-xs font-bold
                         {% if game.statusType == 'inprogress' %}bg-green-500/15 text-green-700 dark:text-green-300
                         {% elif game.statusType == 'finished' %}bg-slate-500/15 text-slate-700 dark:text-slate-300
                         {% else %}bg-blue-500/15 text-blue-700 dark:text-blue-300{% endif %}">
                         {% if game.statusType == 'inprogress' %}<span class="h-2 w-2 rounded-full bg-green-500 animate-pulse"></span>{% endif %}
-                        {{ game.statusTitle }}
+                        <span data-status-title>{{ game.statusTitle }}</span>
                     </span>
                     <span class="text-right text-xs font-semibold text-text-secondary-light dark:text-text-secondary">
                         {{ game.startTimestamp|date:"D, M j" }}{% with game|game_start_label as start_label %}{% if start_label %}<span class="mx-1 opacity-50">&middot;</span>{{ start_label }}{% endif %}{% endwith %}
@@ -271,7 +271,7 @@
                         </span>
                         <span class="flex items-center gap-1.5 font-black text-text-dark dark:text-white">
                             {% if game.statusType == 'finished' and game.gameWinner == game.awayTeamSlug %}<i class="fas fa-trophy text-xs text-yellow-500" title="{{ game.awayTeamName }} won" aria-label="Winner"></i>{% endif %}
-                            {{ game.awayTeamScore|default:"-" }}
+                            <span data-away-score>{{ game.awayTeamScore|default:"-" }}</span>
                         </span>
                     </div>
                     <div class="flex items-center justify-between gap-3{% if game.statusType == 'finished' and game.gameWinner and game.gameWinner != game.homeTeamSlug %} opacity-60{% endif %}">
@@ -283,7 +283,7 @@
                         </span>
                         <span class="flex items-center gap-1.5 font-black text-text-dark dark:text-white">
                             {% if game.statusType == 'finished' and game.gameWinner == game.homeTeamSlug %}<i class="fas fa-trophy text-xs text-yellow-500" title="{{ game.homeTeamName }} won" aria-label="Winner"></i>{% endif %}
-                            {{ game.homeTeamScore|default:"-" }}
+                            <span data-home-score>{{ game.homeTeamScore|default:"-" }}</span>
                         </span>
                     </div>
                 </div>
@@ -847,6 +847,100 @@
         // repeated failures with no data. There's no 30s poll fallback on
         // this page, so give-up just means the podium stops live-updating
         // until the next full page load.
+        sseErrorCount++;
+        if (sseErrorCount >= 3) {
+            try { sseSource.close(); } catch (e) {}
+            sseSource = null;
+        }
+    };
+})();
+</script>
+
+<!-- Live game scores for the "This Week's Games" tiles via the same scores SSE
+     the /scores page uses. Score/status text is patched in place (no flash);
+     a status transition (which adds winner trophies, dims the loser, and
+     reveals pick groups) triggers a debounced refetch that swaps only the
+     cards whose markup actually changed — unchanged cards are never touched. -->
+<script>
+(function () {
+    if (!window.EventSource) { return; }
+    var page = document.querySelector('[data-lobby-page]');
+    var week = page && page.dataset ? page.dataset.liveWeek : '';
+    var grid = document.querySelector('[data-lobby-games-grid]');
+    if (!week || !grid) { return; }
+
+    // Debounced refetch of the lobby page; swap only game cards whose innerHTML
+    // changed (status transition), leaving unchanged cards — and the rest of the
+    // page — untouched. No fade: a status flip is infrequent and reads cleanly.
+    var refetchTimer = null;
+    var refetchGeneration = 0;
+    function scheduleGamesRefetch() {
+        var generation = ++refetchGeneration;
+        if (refetchTimer) { clearTimeout(refetchTimer); }
+        refetchTimer = setTimeout(function () {
+            refetchTimer = null;
+            fetch(window.location.href, {
+                headers: { 'X-Requested-With': 'XMLHttpRequest', 'Cache-Control': 'no-store' },
+                cache: 'no-store', credentials: 'same-origin'
+            }).then(function (r) { return r.ok ? r.text() : null; })
+              .then(function (html) {
+                  if (!html || generation !== refetchGeneration) { return; }
+                  var doc = new DOMParser().parseFromString(html, 'text/html');
+                  var freshCards = {};
+                  doc.querySelectorAll('[data-lobby-game-card]').forEach(function (c) {
+                      freshCards[c.getAttribute('data-game-id')] = c;
+                  });
+                  grid.querySelectorAll('[data-lobby-game-card]').forEach(function (cur) {
+                      var fresh = freshCards[cur.getAttribute('data-game-id')];
+                      if (!fresh) { return; }
+                      if (cur.innerHTML !== fresh.innerHTML) {
+                          cur.innerHTML = fresh.innerHTML;
+                          // Keep the status attr in sync so later score-only
+                          // patches compare against the current status.
+                          cur.setAttribute('data-game-status',
+                              fresh.getAttribute('data-game-status'));
+                      }
+                  });
+              }).catch(function () {});
+        }, 1200);
+    }
+
+    function applyScoreEvent(ev) {
+        var d;
+        try { d = JSON.parse(ev.data); } catch (e) { return; }
+        var card = grid.querySelector(
+            '[data-lobby-game-card][data-game-id="' + d.game_id + '"]');
+        if (!card) { return; }
+        if (card.getAttribute('data-game-status') !== d.status) {
+            // Status transition changes card structure (trophies, dimming, pick
+            // groups) — mark the new status and refetch to swap the card.
+            card.setAttribute('data-game-status', d.status);
+            scheduleGamesRefetch();
+            return;
+        }
+        // Same status: patch score + clock text in place, no repaint.
+        var home = card.querySelector('[data-home-score]');
+        var away = card.querySelector('[data-away-score]');
+        if (home && d.home_score !== null && d.home_score !== undefined) {
+            home.textContent = d.home_score;
+        }
+        if (away && d.away_score !== null && d.away_score !== undefined) {
+            away.textContent = d.away_score;
+        }
+        var title = card.querySelector('[data-status-title]');
+        if (title && d.status_title) { title.textContent = d.status_title; }
+    }
+
+    var sseSource = null;
+    var sseErrorCount = 0;
+    try {
+        sseSource = new EventSource(
+            '/events/scores/?week=' + encodeURIComponent(week));
+    } catch (e) { return; }
+    sseSource.onmessage = function (ev) { sseErrorCount = 0; applyScoreEvent(ev); };
+    sseSource.onerror = function () {
+        // Same give-up-after-repeated-failures policy as the standings stream;
+        // no poll fallback, so the tiles just stop updating until a page load.
         sseErrorCount++;
         if (sseErrorCount >= 3) {
             try { sseSource.close(); } catch (e) {}

--- a/pickem/pickem_homepage/templates/pickem/scores.html
+++ b/pickem/pickem_homepage/templates/pickem/scores.html
@@ -1430,6 +1430,14 @@
             // un-initialized/hidden markup until a full page reload. Re-run the
             // swapped-in scripts so a live transition "unlocks" the card
             // exactly like a fresh load.
+            //
+            // NOTE for card-partial authors: keep per-card inline scripts wrapped
+            // in an IIFE ((function(){ ... })()). This helper re-runs them on every
+            // live swap, so a top-level `let`/`const` would throw a redeclaration
+            // SyntaxError on the second swap — and because that surfaces via the
+            // global error handler (not this call's try/catch), it would fail
+            // silently with no user-facing "update failed" signal. IIFEs re-run
+            // safely (the two current card scripts already are).
             function runInlineScripts(container) {
                 container.querySelectorAll('script').forEach(function (old) {
                     const s = document.createElement('script');

--- a/pickem/pickem_homepage/templates/pickem/scores.html
+++ b/pickem/pickem_homepage/templates/pickem/scores.html
@@ -1464,11 +1464,9 @@
                         currentGame.classList.toggle('scores-live-game', newStatus === 'inprogress');
                         
                         
-                        // Add update animation
-                        currentGame.style.animation = 'none';
-                        currentGame.offsetHeight; // Trigger reflow
-                        currentGame.style.animation = 'fadeIn 0.5s ease-in';
-                        
+                        // Content was swapped in above; no per-update card fade
+                        // (it flashed the whole card). Status transitions are
+                        // infrequent, so the instant swap reads cleanly.
                         gamesUpdated++;
                         
                         // Check if game just completed
@@ -1495,7 +1493,6 @@
             const newStats = newDoc.querySelector('.weekly-performance-stats');
             if (currentStats && newStats && currentStats.innerHTML !== newStats.innerHTML) {
                 currentStats.innerHTML = newStats.innerHTML;
-                currentStats.style.animation = 'fadeIn 0.5s ease-in';
             }
             
             // Update week points leaderboard
@@ -1503,8 +1500,7 @@
             const newLeaderboard = newDoc.getElementById('week-points-leaderboard');
             if (currentLeaderboard && newLeaderboard && currentLeaderboard.innerHTML !== newLeaderboard.innerHTML) {
                 currentLeaderboard.innerHTML = newLeaderboard.innerHTML;
-                currentLeaderboard.style.animation = 'fadeIn 0.5s ease-in';
-                
+
                 // Refresh the Week Points layout after updating leaderboard content
                 if (typeof window.weekPointsLayoutManager !== 'undefined') {
                     setTimeout(() => {
@@ -1666,8 +1662,9 @@
             });
         }
 
-        // reuse existing update animation + completion handling
-        card.style.animation = 'none'; card.offsetHeight; card.style.animation = 'fadeIn 0.5s ease-in';
+        // The score/period text was patched in place above; do NOT fade the
+        // whole card on every tick — that flashed the entire card on every
+        // score change. The continuous "live" glow (scoresLivePulse) is kept.
         if (window.scoresLivePulse) window.scoresLivePulse();
     }
 

--- a/pickem/pickem_homepage/templates/pickem/scores.html
+++ b/pickem/pickem_homepage/templates/pickem/scores.html
@@ -1422,7 +1422,25 @@
             
             let gamesUpdated = 0;
             let completedGames = 0;
-            
+
+            // <script> tags inserted via innerHTML never execute, so the
+            // per-card inline setup scripts (pick placeholders, missing-picks
+            // reveal) would not run after a live card swap — leaving a game
+            // that just transitioned (e.g. scheduled -> in progress) with
+            // un-initialized/hidden markup until a full page reload. Re-run the
+            // swapped-in scripts so a live transition "unlocks" the card
+            // exactly like a fresh load.
+            function runInlineScripts(container) {
+                container.querySelectorAll('script').forEach(function (old) {
+                    const s = document.createElement('script');
+                    for (const attr of old.attributes) {
+                        s.setAttribute(attr.name, attr.value);
+                    }
+                    s.textContent = old.textContent;
+                    old.parentNode.replaceChild(s, old);
+                });
+            }
+
             currentGames.forEach((currentGame, index) => {
                 if (newGames[index]) {
                     const currentStatus = currentGame.getAttribute('data-game-status');
@@ -1462,8 +1480,10 @@
                         currentGame.innerHTML = newGames[index].innerHTML;
                         currentGame.setAttribute('data-game-status', newStatus);
                         currentGame.classList.toggle('scores-live-game', newStatus === 'inprogress');
-                        
-                        
+                        // Re-run the swapped-in inline scripts (see above) so the
+                        // now-in-progress card initializes without a manual reload.
+                        runInlineScripts(currentGame);
+
                         // Content was swapped in above; no per-update card fade
                         // (it flashed the whole card). Status transitions are
                         // infrequent, so the instant swap reads cleanly.

--- a/pickem/pickem_homepage/tests.py
+++ b/pickem/pickem_homepage/tests.py
@@ -613,7 +613,12 @@ class TenantDashboardIsolationTests(TestCase):
         without a ScrollTrigger.refresh() after a page change the "Upcoming"
         games section — held at autoAlpha:0 while below the fold — never fires
         and stays hidden. Lock the guarded refresh into the pager's render()
-        (bug: games tiles fail to render on Week Points pages past page 1)."""
+        (bug: games tiles fail to render on Week Points pages past page 1).
+
+        The refresh is now gated behind a skipScrollRefresh flag so the live
+        update path can suppress it (see the no-flash test below); manual page
+        navigation still refreshes. This test asserts the refresh is present and
+        inside render(); the gating is asserted separately."""
         family, pool = self._family_with_pool("Smith Family", "smith-family")
         self._active_membership(self.member, family)
         # Seed more than one page (page size is 12) so the pager is actually
@@ -635,8 +640,35 @@ class TenantDashboardIsolationTests(TestCase):
         # The refresh must live *inside* the pager's render(), after it toggles
         # row visibility — not merely somewhere on the page — and be guarded for
         # reduced-motion / no-GSAP.
-        render_body = html.split("function render()", 1)[1].split("function refresh()", 1)[0]
+        render_body = html.split("function render(", 1)[1].split("function refresh(", 1)[0]
         self.assertRegex(render_body, r"window\.ScrollTrigger\s*&&\s*window\.ScrollTrigger\.refresh\(\)")
+
+    def test_live_week_points_update_patches_in_place_without_full_flash(self):
+        """A live standings update must NOT rebuild the whole Week Points grid.
+
+        The old handler did `current.innerHTML = fresh.innerHTML`, tearing down
+        and repainting every tile on every event (a constant full-panel flash
+        during scoring) and calling ScrollTrigger.refresh() — which re-fired the
+        GSAP reveal on other lobby sections. The fix reconciles tiles in place
+        (reusing nodes) and only refreshes ScrollTriggers on a structural change.
+        Lock that so the flash can't regress."""
+        family, pool = self._family_with_pool("Smith Family", "smith-family")
+        self._active_membership(self.member, family)
+        userSeasonPoints.objects.create(
+            pool=pool, userEmail=self.member.email, userID=str(self.member.id),
+            gameseason=get_season(), gameyear="2025", week_1_points=3, total_points=3,
+        )
+        self.client.force_login(self.member)
+        html = self.client.get(self._tenant_url(family, pool)).content.decode()
+
+        # The in-place reconcile exists and is what the refetch calls.
+        self.assertIn("function reconcileWeekPoints(", html)
+        self.assertIn("reconcileWeekPoints(current, fresh)", html)
+        # The wholesale grid innerHTML swap must be gone (it was the flash).
+        self.assertNotIn("current.innerHTML = fresh.innerHTML", html)
+        # The live refetch re-paginates with the ScrollTrigger refresh suppressed
+        # unless the member set changed, so other sections don't re-animate.
+        self.assertIn("__weekPointsPaginate(!structural)", html)
 
     def test_pool_home_is_branded_as_lobby_with_gsap_polish(self):
         smith_family, smith_pool = self._family_with_pool("Smith Family", "smith-family")

--- a/pickem/pickem_homepage/tests.py
+++ b/pickem/pickem_homepage/tests.py
@@ -903,13 +903,21 @@ class TenantDashboardIsolationTests(TestCase):
         self.client.force_login(self.member)
         html = self.client.get(self._tenant_url(smith_family, smith_pool)).content.decode()
 
-        # Per-tile hooks the client finds/patches, all on the same card (id 1050).
-        self.assertRegex(html, r'data-lobby-game-card data-game-id="1050"')
-        self.assertIn("data-game-status=", html)
-        self.assertIn("data-home-score", html)
-        self.assertIn("data-away-score", html)
-        self.assertIn("data-status-title", html)
+        # Scope the per-tile hooks to the games grid (not merely "somewhere on
+        # the page") so unrelated markup can't satisfy them. The card's identity
+        # + status attrs must sit together on the card element the client finds.
         self.assertIn("data-lobby-games-grid", html)
+        grid = html.split("data-lobby-games-grid", 1)[1]
+        self.assertRegex(
+            grid,
+            r'data-lobby-game-card data-game-id="1050" data-game-status="inprogress"',
+        )
+        self.assertIn("data-home-score", grid)
+        self.assertIn("data-away-score", grid)
+        self.assertIn("data-status-title", grid)
+        # data-live-week must render a real week number — the scores SSE URL is
+        # built from it, so an empty value would silently disable live updates.
+        self.assertRegex(html, r'data-live-week="\d+"')
         # Subscribes to the scores SSE and patches in place (no full-grid swap).
         self.assertIn("/events/scores/?week=", html)
         self.assertIn("function applyScoreEvent(", html)

--- a/pickem/pickem_homepage/tests.py
+++ b/pickem/pickem_homepage/tests.py
@@ -3370,6 +3370,22 @@ class TenantProfilesPlayersMessageBoardIsolationTests(TestCase):
         self.assertContains(response, "updateInterval = null;")
         self.assertContains(response, "document.removeEventListener('visibilitychange', window.visibilityHandler);")
 
+    def test_scores_live_update_patches_in_place_without_card_fade(self):
+        """Live score ticks patch score/period text in place; they must NOT
+        fade the whole card on every update. The old code ran
+        `card.style.animation = 'fadeIn 0.5s ease-in'` on every SSE tick, which
+        flashed the entire card during scoring (user-reported). Lock that the
+        SSE handler no longer fades the card while still patching in place and
+        keeping the continuous 'live' glow."""
+        self.client.force_login(self.smith_member)
+        html = self.client.get(self._tenant_url("family_pool_scores")).content.decode()
+        # Isolate the SSE apply handler; it must patch in place, not fade.
+        sse_body = html.split("function applyScoreEvent(", 1)[1].split(
+            "function startSse(", 1)[0]
+        self.assertNotIn("fadeIn", sse_body)
+        self.assertIn("data-home-score", sse_body)   # still patches scores in place
+        self.assertIn("scoresLivePulse", sse_body)   # keeps the live glow
+
     def test_tenant_create_post_assigns_current_family_server_side(self):
         self.client.force_login(self.smith_member)
 

--- a/pickem/pickem_homepage/tests.py
+++ b/pickem/pickem_homepage/tests.py
@@ -907,7 +907,11 @@ class TenantDashboardIsolationTests(TestCase):
         # the page") so unrelated markup can't satisfy them. The card's identity
         # + status attrs must sit together on the card element the client finds.
         self.assertIn("data-lobby-games-grid", html)
-        grid = html.split("data-lobby-games-grid", 1)[1]
+        # Bound the slice to the card markup (stop at the first <script>) so the
+        # SSE script's selector literals ([data-home-score] etc.) further down
+        # the page cannot satisfy these assertions — otherwise the test would
+        # pass even if the tiles lost the attributes it claims to lock.
+        grid = html.split("data-lobby-games-grid", 1)[1].split("<script", 1)[0]
         self.assertRegex(
             grid,
             r'data-lobby-game-card data-game-id="1050" data-game-status="inprogress"',

--- a/pickem/pickem_homepage/tests.py
+++ b/pickem/pickem_homepage/tests.py
@@ -883,6 +883,37 @@ class TenantDashboardIsolationTests(TestCase):
         self.assertNotContains(response, "Jones family secret")
         self.assertNotContains(response, "2 of 1")
 
+    def test_lobby_game_tiles_carry_live_score_hooks_and_subscribe(self):
+        """The lobby "This Week's Games" tiles must live-update via the scores
+        SSE (previously only the /scores page did). Lock the per-tile hooks the
+        client patches (data-game-id/status, data-home-score/away-score,
+        data-status-title) and the /events/scores/ subscription + in-place
+        apply handler, so the games tiles can't silently regress to static."""
+        smith_family, smith_pool = self._family_with_pool("Smith Family", "smith-family")
+        self._active_membership(self.member, smith_family)
+        GamesAndScores.objects.create(
+            id=1050, slug="buf-nyj-2025-week-1", competition="nfl",
+            gameWeek="1", gameyear="2025", gameseason=2526,
+            startTimestamp=timezone.now() - timedelta(hours=1),
+            statusType="inprogress", statusTitle="Q3 5:22",
+            homeTeamId=3, homeTeamSlug="nyj", homeTeamName="New York Jets",
+            homeTeamScore=14, awayTeamId=4, awayTeamSlug="buf",
+            awayTeamName="Buffalo Bills", awayTeamScore=17,
+        )
+        self.client.force_login(self.member)
+        html = self.client.get(self._tenant_url(smith_family, smith_pool)).content.decode()
+
+        # Per-tile hooks the client finds/patches, all on the same card (id 1050).
+        self.assertRegex(html, r'data-lobby-game-card data-game-id="1050"')
+        self.assertIn("data-game-status=", html)
+        self.assertIn("data-home-score", html)
+        self.assertIn("data-away-score", html)
+        self.assertIn("data-status-title", html)
+        self.assertIn("data-lobby-games-grid", html)
+        # Subscribes to the scores SSE and patches in place (no full-grid swap).
+        self.assertIn("/events/scores/?week=", html)
+        self.assertIn("function applyScoreEvent(", html)
+
     def test_dashboard_snapshot_weekday_selection_rules(self):
         from pickem_homepage.views import select_dashboard_snapshot_games
 

--- a/pickem/pickem_homepage/tests.py
+++ b/pickem/pickem_homepage/tests.py
@@ -3386,6 +3386,20 @@ class TenantProfilesPlayersMessageBoardIsolationTests(TestCase):
         self.assertIn("data-home-score", sse_body)   # still patches scores in place
         self.assertIn("scoresLivePulse", sse_body)   # keeps the live glow
 
+    def test_scores_live_card_swap_reexecutes_inline_scripts(self):
+        """A live card swap replaces card innerHTML; <script> tags inserted via
+        innerHTML never execute, so the per-card inline setup scripts (pick
+        placeholders, missing-picks reveal) would not run — leaving a game that
+        just transitioned scheduled->in-progress with un-initialized/hidden
+        markup until a full page reload (user-reported "had to refresh to
+        unlock"). Lock that the swap re-runs the inline scripts."""
+        self.client.force_login(self.smith_member)
+        html = self.client.get(self._tenant_url("family_pool_scores")).content.decode()
+        # The re-execution helper exists and is invoked right after the swap.
+        self.assertIn("function runInlineScripts(", html)
+        self.assertIn("currentGame.innerHTML = newGames[index].innerHTML;", html)
+        self.assertIn("runInlineScripts(currentGame);", html)
+
     def test_tenant_create_post_assigns_current_family_server_side(self):
         self.client.force_login(self.smith_member)
 


### PR DESCRIPTION
## Summary

Frontend live-update UX fixes surfaced by watching a full simulated weekend against the live SSE surfaces. All changes are client-side JS inside Django templates — no backend/schema changes.

- **Lobby Week Points — stop the flash.** The standings-SSE handler replaced the entire Week Points grid's `innerHTML` on every event (debounced 1.5s), repainting every tile even when one changed — a constant full-panel flash during scoring — and re-fired the GSAP reveal on other lobby sections. Now reconciles tiles in place (reuse nodes keyed by `data-user-id`, patch only changed tiles, reorder with a subtle ~220ms FLIP slide respecting `prefers-reduced-motion`), and only refreshes ScrollTriggers on a structural change. The initial page-load reveal is unchanged.
- **Scores page — stop the card flash.** Removed the per-update `fadeIn` on cards/stats/leaderboard; scores tick in place. The continuous "live" glow and the one-shot green completion border are kept.
- **Scores page — unlock on transition.** A live card swap replaces `innerHTML`, but `<script>` tags inserted that way never execute, so a game going scheduled→in-progress left its card un-initialized until a manual reload. The swapped-in inline scripts are now re-executed.
- **Lobby "This Week's Games" tiles — now live.** Previously a static page-load snapshot. Wired to the same `/events/scores/` stream: score/status text patches in place, and a status transition (which adds winner trophies, dims the loser, reveals pick groups) triggers a debounced refetch that swaps only the cards whose markup changed.

## Testing

- Full suite green (`937 tests, OK`).
- No JS test runner in this repo, so new tests lock the **DOM contract** the client JS depends on (data-* hooks, SSE subscription URLs, key function presence), scoped to the relevant elements. Runtime behavior verified manually via browser isolation testing (mock EventSource → real handlers → asserted in-place DOM patches).
- Local multi-agent review applied: added `console.error` to the best-effort refetch catches (so a real reconcile bug is distinguishable from a network blip), an IIFE warning on `runInlineScripts`, and tightened test assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Live lobby updates now refresh game scores, statuses, and Week Points without replacing the entire view.
  * Week Points tiles are added, removed, and reordered smoothly while preserving existing content.
  * Score updates now initialize newly displayed pick and missing-pick details correctly.
* **Bug Fixes**
  * Eliminated distracting flashes and unnecessary fade effects during live score and leaderboard updates.
  * Pagination and live updates now avoid unnecessary layout refreshes.
  * Updates respect reduced-motion accessibility preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->